### PR TITLE
Adds timestamp to list view

### DIFF
--- a/database.go
+++ b/database.go
@@ -133,7 +133,7 @@ func (db *DB) Recent(limit int) ([]*SearchResult, error) {
 	err = db.Select(&res, `
 		SELECT
 			docs.id, docs.filename, docs.md5, docs.modified_at,
-			REPLACE(substr(cti.text, 0, 120), char(10), ' ') as snippet
+			REPLACE(substr(cti.text, 0, 180), char(10), ' ') as snippet
 		FROM
 			documents docs
 		INNER JOIN

--- a/list_box_test.go
+++ b/list_box_test.go
@@ -24,39 +24,46 @@ func TestFormatResult(t *testing.T) {
 		expected   string
 	}{
 		{
-			name:       "simple test",
-			filename:   "test.txt",
-			snippet:    "This is a test snippet",
-			maxWidth:   -1,
-			modifiedAt: "2023-10-01T15:04:05Z",
-			expected:   "test                     This is a test snippet",
+			name:     "width not specified",
+			filename: "test.txt",
+			snippet:  "This is a test snippet",
+			expected: "test                   This is a test snippet          Jan 01, 2001",
 		},
 		{
-			name:       "width includes date",
+			name:       "adds spaces to snippet to equal width",
+			filename:   "test.txt",
+			snippet:    "This is a test snippet",
+			maxWidth:   90,
+			modifiedAt: "2023-10-01T15:04:05Z",
+			expected:   "test                   This is a test snippet                                 Oct 01, 2023",
+		},
+		{
+			name:       "timestamp is formatted correctly",
 			filename:   "test_file.txt",
 			snippet:    "This is a test snippet",
 			maxWidth:   70,
 			modifiedAt: "2006-01-02T15:04:05Z",
-			expected:   "test_file                This is a test snippet           Jan 02, 2006",
+			expected:   "test_file              This is a test snippet             Jan 02, 2006",
 		},
 		{
 			name:     "no width specified",
 			filename: "test_file.txt",
 			snippet:  "package nve\n\nimport ( \"fmt\"\n\"log\"\n\"math\"\n\"strings\"\n\"time\"\n\"github.com/gdamore/tcell/v2\"",
-			expected: `test_file                package nve import ( "fmt" "log" "math" "strings" "time" "github.com/gdamore/tcell/v2"         Jan 01, 2001`,
+			expected: `test_file              package nve import ( "fmt" "log" "math" "strings" "time" "github.com/gdamore/tcell/v2"          Jan 01, 2001`,
+			maxWidth: -1,
 		},
 		{
 			name:     "width truncates",
 			filename: "test_file.txt",
 			snippet:  "package nve\n\nimport ( \"fmt\"\n\"log\"\n\"math\"\n\"strings\"\n\"time\"\n\"github.com/gdamore/tcell/v2\"",
-			expected: `test_file                package nve import ( "fmt" "log" "math" "strings" "time" "github.com/gda..         Jan 01, 2001`,
+			expected: `test_file              package nve import ( "fmt" "log" "math" "strings" "time" "github.com/gdam..          Jan 01, 2001`,
 			maxWidth: 120,
 		},
 		{
-			name:     "width is narrow",
+			name:     "width too narrow to fit more than two characters of snippet removes filename and timestamp",
 			filename: "test_file.txt",
 			snippet:  "package nve\n\nimport ( \"fmt\"\n\"log\"\n\"math\"\n\"strings\"\n\"time\"\n\"github.com/gdamore/tcell/v2\"",
-			expected: `test_file                package nve import ( "fmt" "log" "math" "strings" "time" "github.com/gda..         Jan 01, 2001`,
+			expected: `package nve import ( "fmt" "log" "math..`,
 			maxWidth: 40,
 		},
 	}
@@ -83,10 +90,11 @@ func TestFormatResult(t *testing.T) {
 
 			actual := formatResult(result, tt.maxWidth)
 
-			if len(tt.snippet) > tt.maxWidth && tt.maxWidth > 0 {
+			if tt.maxWidth > 0 {
 				// Ensure that the snippet was truncated appropriately
-				assert.Equal(t, len(actual), tt.maxWidth)
+				assert.Equal(t, len(actual), len(tt.expected))
 			}
+
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/list_box_test.go
+++ b/list_box_test.go
@@ -1,0 +1,93 @@
+package nve
+
+import (
+	"io"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	// Disable logging during tests
+	log.SetOutput(io.Discard)
+}
+
+func TestFormatResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		filename   string
+		snippet    string
+		maxWidth   int
+		modifiedAt string
+		expected   string
+	}{
+		{
+			name:       "simple test",
+			filename:   "test.txt",
+			snippet:    "This is a test snippet",
+			maxWidth:   -1,
+			modifiedAt: "2023-10-01T15:04:05Z",
+			expected:   "test                     This is a test snippet",
+		},
+		{
+			name:       "width includes date",
+			filename:   "test_file.txt",
+			snippet:    "This is a test snippet",
+			maxWidth:   70,
+			modifiedAt: "2006-01-02T15:04:05Z",
+			expected:   "test_file                This is a test snippet           Jan 02, 2006",
+		},
+		{
+			name:     "no width specified",
+			filename: "test_file.txt",
+			snippet:  "package nve\n\nimport ( \"fmt\"\n\"log\"\n\"math\"\n\"strings\"\n\"time\"\n\"github.com/gdamore/tcell/v2\"",
+			expected: `test_file                package nve import ( "fmt" "log" "math" "strings" "time" "github.com/gdamore/tcell/v2"         Jan 01, 2001`,
+		},
+		{
+			name:     "width truncates",
+			filename: "test_file.txt",
+			snippet:  "package nve\n\nimport ( \"fmt\"\n\"log\"\n\"math\"\n\"strings\"\n\"time\"\n\"github.com/gdamore/tcell/v2\"",
+			expected: `test_file                package nve import ( "fmt" "log" "math" "strings" "time" "github.com/gda..         Jan 01, 2001`,
+			maxWidth: 120,
+		},
+		{
+			name:     "width is narrow",
+			filename: "test_file.txt",
+			snippet:  "package nve\n\nimport ( \"fmt\"\n\"log\"\n\"math\"\n\"strings\"\n\"time\"\n\"github.com/gdamore/tcell/v2\"",
+			expected: `test_file                package nve import ( "fmt" "log" "math" "strings" "time" "github.com/gda..         Jan 01, 2001`,
+			maxWidth: 40,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.modifiedAt == "" {
+				tt.modifiedAt = "2001-01-01T15:04:05Z"
+			}
+
+			modifiedAt, _ := time.Parse(time.RFC3339, tt.modifiedAt)
+
+			fileRef := &FileRef{
+				DocumentID: 1,
+				Filename:   tt.filename,
+				MD5:        "abc123",
+				ModifiedAt: modifiedAt,
+			}
+
+			result := &SearchResult{
+				FileRef: fileRef,
+				Snippet: tt.snippet,
+			}
+
+			actual := formatResult(result, tt.maxWidth)
+
+			if len(tt.snippet) > tt.maxWidth && tt.maxWidth > 0 {
+				// Ensure that the snippet was truncated appropriately
+				assert.Equal(t, len(actual), tt.maxWidth)
+			}
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/notes_test.go
+++ b/notes_test.go
@@ -104,7 +104,7 @@ func TestNotifyObservers(t *testing.T) {
 		res := mock.lastResult[0]
 
 		// assert snippet
-		assert.Equal(t, "new york\n**seattle**\n", res.Snippet)
+		assert.Equal(t, "new york **seattle** ", res.Snippet)
 
 		// assert filename
 		assert.Equal(t, "test_data/apples in zoo.md", res.Filename)


### PR DESCRIPTION
<img width="1716" height="282" alt="CleanShot 2025-09-21 at 19 01 07@2x" src="https://github.com/user-attachments/assets/3053193f-f692-4348-9999-f48478667aa0" />

This adds the file's timestamp to the list box view and dynamically adjusts the content/preview of each line.
