### PR TITLE
Monitor for and respond to filesystem changes

### DIFF
--- a/.claude/agents/go-simplifier.md
+++ b/.claude/agents/go-simplifier.md
@@ -1,0 +1,112 @@
+---
+name: go-simplifier
+description: "Use this agent when Go code has been written or modified and needs to be reviewed for simplification opportunities, idiomatic Go compliance, and refactoring. This includes simplifying function signatures, eliminating near-duplicate functions, flattening nested conditionals, converting tests to table-driven format, and externalizing large test fixtures.\\n\\nExamples:\\n\\n- User: \"I just added a new search function to notes.go\"\\n  Assistant: \"Let me review that code for simplification opportunities.\"\\n  [Uses Task tool to launch go-simplifier agent to review the changes in notes.go]\\n\\n- User: \"I wrote tests for the database layer\"\\n  Assistant: \"Let me use the go-simplifier agent to check if those tests follow table-driven patterns and idiomatic Go.\"\\n  [Uses Task tool to launch go-simplifier agent to review the test files]\\n\\n- User: \"Can you refactor the UI handler code?\"\\n  Assistant: \"I'll use the go-simplifier agent to analyze the code and suggest simplifications.\"\\n  [Uses Task tool to launch go-simplifier agent to review and refactor the UI handler code]"
+model: opus
+memory: project
+---
+
+You are an expert Go code simplifier and refactoring specialist with deep knowledge of idiomatic Go, the Go proverbs, and the conventions established by the Go standard library and community. You have extensive experience with code review at top Go shops and you are uncompromising about simplicity and clarity.
+
+**Your Mission**: Review recent changes or modified Go code and produce concrete, actionable simplifications. You explain each change and why it is safe, and then implement the changes directly.
+
+**Critical Build Requirement**: This project requires `--tags=fts5` for all build and test commands. Always use `go test ./... --tags=fts5 --count=1` when running tests.
+
+## What You Look For
+
+### 1. Function Signature Simplification
+- Functions accepting interfaces they don't need — narrow to the minimal interface
+- Parameters that are always the same value — consider removing or using defaults
+- Return values that callers consistently ignore — question whether they're needed
+- Functions taking multiple parameters of the same type — consider a struct or options pattern only if there are 5+
+- Exported functions that don't need to be exported
+
+### 2. Near-Duplicate Function Elimination
+- Functions with >70% similar logic — extract the common part
+- Functions differing only in a type — use generics if Go 1.18+ or extract the varying part as a parameter
+- Copy-pasted blocks across functions — extract into a helper
+- When you find duplicates, refactor them and verify all call sites still work
+
+### 3. Conditional Logic Flattening
+- **Early returns over nesting**: Convert `if cond { <big block> } else { return err }` to `if !cond { return err }; <big block>`
+- **Guard clauses**: Move error checks and edge cases to the top of functions
+- **No else after return**: If an `if` block returns, the `else` is unnecessary
+- **Switch over if-else chains**: When 3+ conditions check the same variable, use a switch
+- **Avoid boolean parameters** that create internal if/else branches — consider two functions instead
+
+### 4. Table-Driven Tests
+- Convert any test with repeated similar test logic into table-driven format
+- Use `t.Run(name, func(t *testing.T) { ... })` for subtests
+- Name test cases descriptively: what's being tested, not "test1", "test2"
+- Use `t.Helper()` in test helper functions
+- Use `t.Parallel()` where tests are independent
+
+### 5. Test Fixture Management
+- Fixtures larger than ~10 lines of literal data should be in `test_data/` files
+- Use `os.ReadFile` or `embed` to load test data
+- Golden files for complex expected output
+- Shared setup should use `TestMain` or helper functions, not repeated inline setup
+
+### 6. General Idiomatic Go
+- Use `errors.Is`/`errors.As` over string comparison
+- Use `fmt.Errorf("...: %w", err)` for error wrapping
+- Prefer `var ErrFoo = errors.New("foo")` sentinel errors over inline strings
+- Zero values: don't initialize variables to their zero value unnecessarily
+- Use short variable declarations (`:=`) where appropriate
+- Receiver names: short, consistent, not `this` or `self`
+- Comment exported symbols with the symbol name as the first word
+- Don't stutter: `notes.NotesManager` → `notes.Manager`
+
+## Workflow
+
+1. **Read the recently changed files** to understand what was written or modified
+2. **Identify all simplification opportunities** across the categories above
+3. **Prioritize**: Fix structural issues (duplicates, signature problems) before cosmetic ones
+4. **Implement changes directly** in the code — don't just list suggestions
+5. **Run tests** with `go test ./... --tags=fts5 --count=1` to verify nothing breaks
+6. **If tests fail**, diagnose and fix. If the failure is pre-existing, note it but don't block on it
+7. **Summarize** what you changed and why, organized by category
+
+## Output Format
+
+After making changes, provide a summary structured as:
+
+```
+## Changes Made
+
+### [Category]
+- **File:Line** — What changed and why
+
+### Flagged for Future Refactoring
+- Items that need broader changes beyond the current scope
+```
+
+## Rules
+- Never add complexity in the name of abstraction. If extracting a helper makes the code harder to follow, don't do it.
+- One function should do one thing. If you can't describe what a function does without "and", it probably needs splitting.
+- Be strict. Flag everything that deviates from idiomatic Go, even if it "works fine."
+- When in doubt, look at how the Go standard library does it.
+
+**Update your agent memory** as you discover code patterns, recurring style issues, architectural conventions, and refactoring decisions in this codebase. Write concise notes about what you found and where. Examples of what to record:
+- Common anti-patterns found across files
+- Naming conventions used in the project
+- Test patterns and fixture locations
+- Functions that are candidates for future refactoring
+
+# Persistent Agent Memory
+
+You have a persistent Persistent Agent Memory directory at `/home/ivan/projects/nve/.claude/agent-memory/go-simplifier/`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience. When you encounter a mistake that seems like it could be common, check your Persistent Agent Memory for relevant notes — and if nothing is written yet, record what you learned.
+
+Guidelines:
+- `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it concise
+- Create separate topic files (e.g., `debugging.md`, `patterns.md`) for detailed notes and link to them from MEMORY.md
+- Record insights about problem constraints, strategies that worked or failed, and lessons learned
+- Update or remove memories that turn out to be wrong or outdated
+- Organize memory semantically by topic, not chronologically
+- Use the Write and Edit tools to update your memory files
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. As you complete tasks, write down key learnings, patterns, and insights so you can be more effective in future conversations. Anything saved in MEMORY.md will be included in your system prompt next time.

--- a/.claude/agents/tview-ui-expert.md
+++ b/.claude/agents/tview-ui-expert.md
@@ -1,0 +1,95 @@
+---
+name: tview-ui-expert
+description: "Use this agent when working on terminal UI components using the tview framework, designing new UI panes or widgets, handling focus management, debugging rendering issues, or dealing with concurrency concerns in tview applications. Also use when refactoring existing UI code or adding new keyboard navigation patterns.\\n\\nExamples:\\n\\n- User: \"Add a status bar at the bottom of the screen that shows the current file count\"\\n  Assistant: \"I'll use the tview-ui-expert agent to design and implement the status bar component following our existing UI patterns.\"\\n\\n- User: \"The content box sometimes flickers when updating from a goroutine\"\\n  Assistant: \"This sounds like a tview concurrency issue. Let me use the tview-ui-expert agent to diagnose and fix the threading problem.\"\\n\\n- User: \"I want to add a confirmation dialog when deleting a note\"\\n  Assistant: \"I'll use the tview-ui-expert agent to implement the modal dialog with proper focus management that fits our existing navigation model.\"\\n\\n- User: \"Refactor the ListBox to support multi-select\"\\n  Assistant: \"Let me use the tview-ui-expert agent to redesign the ListBox interaction model while preserving our established keyboard navigation patterns.\""
+model: sonnet
+memory: project
+---
+
+You are an expert terminal UI engineer specializing in Go's tview framework (https://pkg.go.dev/github.com/rivo/tview). You have deep knowledge of tview's widget hierarchy, focus management, input handling, and — critically — its concurrency model.
+
+## Core Expertise
+
+**tview Concurrency Rules** (your most important concern):
+- tview is NOT thread-safe. All UI updates from goroutines MUST use `Application.QueueUpdateDraw()` or `Application.QueueUpdate()`.
+- Never call `SetText()`, `SetCell()`, `Clear()`, or any widget method from a goroutine without wrapping in `QueueUpdateDraw()`.
+- Be vigilant about race conditions between user input handlers (which run on the main goroutine) and background operations (file watchers, search indexers, network calls).
+- When reviewing code, actively look for unprotected cross-goroutine widget access — this is the #1 source of tview bugs.
+
+**tview Widget Knowledge**:
+- Understand the full widget hierarchy: Box, TextView, InputField, List, Table, TreeView, Flex, Grid, Pages, Modal, Form.
+- Know how `SetInputCapture()` and `SetMouseCapture()` work for custom key handling.
+- Understand focus management via `Application.SetFocus()` and how `SetFocusFunc()` / `SetBlurFunc()` callbacks work.
+- Know how to use Flex and Grid for layout composition.
+
+## Project-Specific Patterns (nve)
+
+This project is `nve`, a Notational Velocity-inspired note-taking TUI. You MUST follow these established patterns:
+
+1. **Three-Pane Architecture**: SearchBox (top) → ListBox (middle) → ContentBox (bottom). All new UI elements must integrate with this layout.
+
+2. **Focus Flow**: Tab moves focus SearchBox → ListBox → ContentBox. Escape returns to SearchBox. Any new component must respect this navigation model.
+
+3. **Observer Pattern**: Notes is the central coordinator. UI components observe changes via callback methods like `SearchResultsUpdate()`. New components should follow this pattern rather than directly coupling to data sources.
+
+4. **Debouncing**: Search triggers immediately on text change. File saves use 300ms debounce. The fsnotify watcher debounces at 500ms. Respect these timing patterns.
+
+5. **Focus Guards**: Always check `HasFocus()` before refreshing a component that the user might be actively editing (see ContentBox pattern).
+
+6. **Key Forwarding**: ListBox forwards non-navigational keypresses to SearchBox for seamless typing. Follow this pattern for any new intermediate pane.
+
+7. **setFocus Callbacks**: Components use injected `setFocus` callbacks to transfer focus rather than holding a reference to the Application.
+
+8. **Build Requirements**: Always use `--tags=fts5` for building and testing. CGO is required for SQLite.
+
+## When Writing Code
+
+- Read existing component implementations before creating new ones to match style and patterns.
+- Use the established logging pattern (debug logs to `nve-debug.log`).
+- For any background operation that updates the UI, wrap in `QueueUpdateDraw()`.
+- When capturing variables in closures (especially for goroutines or debounced callbacks), capture by value to avoid nil dereference after Clear() operations.
+- Write tests with `--tags=fts5` and use the existing test patterns in the project.
+
+## When Reviewing Code
+
+- Flag any widget method call from a goroutine not wrapped in `QueueUpdateDraw()`.
+- Flag any closure capturing a pointer that could be nilled by another goroutine.
+- Check that new components integrate with the existing focus flow.
+- Verify that new observers are properly registered and unregistered.
+- Look for missing debounce on operations that could fire rapidly.
+
+## Quality Checks
+
+Before finalizing any implementation:
+1. Verify all goroutine → UI calls use `QueueUpdateDraw()`.
+2. Confirm focus navigation works correctly with Tab/Escape.
+3. Ensure no tight coupling — use the observer pattern.
+4. Check that closures capture values appropriately.
+5. Verify the code builds with `--tags=fts5`.
+
+**Update your agent memory** as you discover UI component patterns, focus management quirks, concurrency pitfalls, and widget customization techniques in this codebase. Write concise notes about what you found and where.
+
+Examples of what to record:
+- Custom input capture patterns and which keys are handled where
+- Focus flow edge cases or workarounds discovered
+- Concurrency bugs found and their fixes
+- Widget composition patterns used in the project
+- Debounce timing decisions and their rationale
+
+# Persistent Agent Memory
+
+You have a persistent Persistent Agent Memory directory at `/home/ivan/projects/nve/.claude/agent-memory/tview-ui-expert/`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience. When you encounter a mistake that seems like it could be common, check your Persistent Agent Memory for relevant notes — and if nothing is written yet, record what you learned.
+
+Guidelines:
+- `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it concise
+- Create separate topic files (e.g., `debugging.md`, `patterns.md`) for detailed notes and link to them from MEMORY.md
+- Record insights about problem constraints, strategies that worked or failed, and lessons learned
+- Update or remove memories that turn out to be wrong or outdated
+- Organize memory semantically by topic, not chronologically
+- Use the Write and Edit tools to update your memory files
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. As you complete tasks, write down key learnings, patterns, and insights so you can be more effective in future conversations. Anything saved in MEMORY.md will be included in your system prompt next time.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 dist/
 *.db
 *.log
+.DS_Store
+
+.conductor
 
 # Claude Code - ignore local settings and agent memory
 .claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 dist/
 *.db
 *.log
+
+# Claude Code - ignore local settings and agent memory
+.claude/settings.local.json
+.claude/agent-memory/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`nve` (Note, View, Edit) is a terminal-based note-taking application inspired by Notational Velocity. It provides a fast, keyboard-driven interface for searching, viewing, creating, and editing plain-text files using the `tview` TUI framework.
+
+## Build and Development Commands
+
+### Building
+```bash
+# Build for current platform
+make build-local
+
+# Build for all platforms (requires goreleaser)
+make build
+
+# Create local release archives
+make release-local
+```
+
+### Testing
+```bash
+# Run all tests (IMPORTANT: must include --tags=fts5 for SQLite FTS support)
+make test
+
+# Run tests directly with Go
+go test ./... --tags=fts5 --count=1
+
+# Run a specific test
+go test -run TestName --tags=fts5
+```
+
+### Running the Application
+```bash
+# Run from source
+go run --tags=fts5 cmd/main.go
+
+# Or run the built binary
+./dist/nve_linux_amd64_v1/nve
+```
+
+**Critical**: Always include `--tags=fts5` when building or testing. This enables SQLite's Full-Text Search (FTS5) extension, which is essential for the application's search functionality.
+
+### Committing code
+
+Prefer desscriptive commits listing the important changes.
+
+* The title describes the intent of the change. It will be retained when squashing commits. (example: "Performance improvements on initial startup")
+* The description is a bulleted list of changes, prefixed with a dash. (example: "- Refactors notes.go to lazy-load file contents.")
+* If changes to go.mod, list the package being updated or introduced with no further comment.
+
+## Architecture
+
+### Three-Pane UI Structure
+
+The application uses a single-threaded TUI with three main components arranged vertically:
+
+1. **SearchBox** (top) - Input field for searching and filtering notes
+2. **ListBox** (middle) - Displays search results with filenames, snippets, and timestamps
+3. **ContentBox** (bottom) - Shows/edits the selected note's full content
+
+Navigation flows: SearchBox → ListBox → ContentBox (using Tab), with Escape returning focus to SearchBox.
+
+### Core Components
+
+- **Notes** (notes.go): Central coordinator that manages the note collection, search operations, and notifies observers of changes. Uses the Observer pattern to update UI components.
+
+- **Database** (database.go): SQLite wrapper with FTS5 for full-text search. Maintains two tables:
+  - `documents`: Stores file metadata (filename, MD5 hash, modification time)
+  - `content_index`: FTS5 virtual table for searching filename and text content
+
+- **UI Boxes**: Each inherits from a `tview` primitive and implements custom input handlers:
+  - `SearchBox`: Debounced search triggering, note creation on Enter when no results
+  - `ListBox`: Displays search results with custom formatting and navigation
+  - `ContentBox`: Editable text area with debounced auto-save (300ms)
+
+### Key Interaction Patterns
+
+1. **Observer Pattern**: Notes notifies ListBox when search results change via `SearchResultsUpdate()`
+
+2. **Focus Coordination**: Components use `setFocus` callbacks to transfer focus between panes. Non-navigational keypresses in ListBox forward to SearchBox for seamless typing.
+
+3. **Debounced Operations**:
+   - Search queries are triggered immediately on text change
+   - File saves are debounced (300ms) to avoid excessive disk writes
+
+4. **File Indexing**: On startup and refresh, the app scans the directory, calculates MD5 hashes, and updates the database only for modified files. Deleted files are pruned from the database.
+
+### File Support
+
+Supported file types: `.txt`, `.md`, `.mdown`, `.go`, `.rb` (see `SUPPORTED_FILETYPES` in files.go)
+
+All files are expected to be plain text and searchable via FTS5.
+
+## Development Notes
+
+- **Logging**: Debug logs are written to `nve-debug.log` in the working directory
+- **Database**: `nve.db` is created in the working directory and persists the search index
+- **Test Data**: The `test_data/` directory contains sample markdown files for testing
+- **CGO**: SQLite driver requires CGO, which is enabled by default but may need special handling for cross-compilation
+
+## Build Configuration
+
+The project uses goreleaser for multi-platform builds:
+- Targets: Linux and macOS (amd64 + arm64)
+- Binary name: `nve`
+- Build flags: `--tags=fts5` (critical for SQLite FTS support)
+- Releases are drafted but not auto-published

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,11 +45,15 @@ go run --tags=fts5 cmd/main.go
 
 ### Committing code
 
-Prefer desscriptive commits listing the important changes.
+Prefer descriptive commits listing the important changes.
 
 * The title describes the intent of the change. It will be retained when squashing commits. (example: "Performance improvements on initial startup")
 * The description is a bulleted list of changes, prefixed with a dash. (example: "- Refactors notes.go to lazy-load file contents.")
 * If changes to go.mod, list the package being updated or introduced with no further comment.
+
+### Addressing PR feedback
+
+When addressing PR review feedback, critically evaluate each comment before applying changes. If you disagree with the feedback or believe it's incorrect, explain your reasoning and ask before making the change.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ build-local:
 test:
 	go test ./... --tags=fts5 --count=1
 
+.PHONY: test-tui
+test-tui:
+	go test --tags="fts5 integration" -run TestTUI --count=1 -v
+
 .PHONY: release-local
 release-local:
 	goreleaser release --snapshot --rm-dist -f .goreleaser.yml

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ The goal is to point 'nve' to a directory of plain-text files, and quickly searc
 
 - 2023/01/16 - Navigation, search and viewing.
 - 2023/02/22 - Saving, creating & displaying snippets
+- 2026/02/06 - Monitoring FS changes
 
 ## TODO
 
 - [x] ✅ Saving edits
 - [x] ✅ Creating new notes from search box
 - [x] ✅ Display snippet in search results
-- [ ] Monitor FS changes to incrementally update DB
+- [x] ✅ Monitor FS changes to incrementally update DB
 - [ ] Support renaming of notes (modal)
 - [ ] Colorize matching search term in content
 - [ ] Syntax highlighting for Markdown files

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,6 +33,11 @@ func main() {
 	notes.RegisterObservers(listBox)
 	notes.Notify()
 
+	if err := notes.StartWatching(func(f func()) { app.QueueUpdateDraw(f) }); err != nil {
+		log.Printf("[WARN] filesystem watcher not available: %v", err)
+	}
+	defer notes.StopWatching()
+
 	// global input events
 	app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {

--- a/content_box.go
+++ b/content_box.go
@@ -65,11 +65,11 @@ func (b *ContentBox) RefreshFile() {
 // flushRefresh reloads the current file from disk if a refresh is pending
 // and the content actually changed. Called when ContentBox loses focus.
 func (b *ContentBox) flushRefresh() {
+	defer func() { b.pendingRefresh = false }()
+
 	if !b.pendingRefresh || b.currentFile == nil {
-		b.pendingRefresh = false
 		return
 	}
-	b.pendingRefresh = false
 	diskContent := GetContent(b.currentFile.Filename)
 	if diskContent != b.GetText() {
 		b.SetText(diskContent, false)

--- a/content_box.go
+++ b/content_box.go
@@ -13,8 +13,9 @@ import (
 
 type ContentBox struct {
 	*tview.TextArea
-	debounce    func(func())
-	currentFile *FileRef
+	debounce       func(func())
+	currentFile    *FileRef
+	pendingRefresh bool
 }
 
 func NewContentBox() *ContentBox {
@@ -36,6 +37,10 @@ func NewContentBox() *ContentBox {
 			textArea.Blur()
 		}
 	})
+
+	textArea.SetBlurFunc(func() {
+		textArea.flushRefresh()
+	})
 	return &textArea
 }
 
@@ -47,6 +52,28 @@ func (b *ContentBox) Clear() {
 func (b *ContentBox) SetFile(f *FileRef) {
 	b.currentFile = f
 	b.SetText(GetContent(f.Filename), false)
+}
+
+// RefreshFile marks that the file may have changed on disk. The actual
+// reload is deferred until the user leaves the editor (via flushRefresh)
+// because calling SetText on a focused TextArea corrupts tview's
+// internal cursor state and causes panics.
+func (b *ContentBox) RefreshFile() {
+	b.pendingRefresh = true
+}
+
+// flushRefresh reloads the current file from disk if a refresh is pending
+// and the content actually changed. Called when ContentBox loses focus.
+func (b *ContentBox) flushRefresh() {
+	if !b.pendingRefresh || b.currentFile == nil {
+		b.pendingRefresh = false
+		return
+	}
+	b.pendingRefresh = false
+	diskContent := GetContent(b.currentFile.Filename)
+	if diskContent != b.GetText() {
+		b.SetText(diskContent, false)
+	}
 }
 
 // InputHandler overrides default handling to switch focus away from search box when necessary.
@@ -99,8 +126,12 @@ func (b *ContentBox) mapSpecialKeys(event *tcell.EventKey) *tcell.EventKey {
 }
 
 func (b *ContentBox) queueSave(content string) {
+	if b.currentFile == nil {
+		return
+	}
+	filename := b.currentFile.Filename
 	b.debounce(func() {
-		err := SaveContent(b.currentFile.Filename, content)
+		err := SaveContent(filename, content)
 
 		if err != nil {
 			log.Println("Error saving content:", err)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/bep/debounce v1.2.1
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gdamore/tcell/v2 v2.5.4
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/mattn/go-sqlite3 v1.14.16
@@ -19,7 +20,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
-	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3IS
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.5.4 h1:TGU4tSjD3sCL788vFNeJnTdzpNKIw1H5dgLnJRQVv/k=
@@ -50,8 +52,8 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.4.0 h1:O7UWfv5+A2qiuulQk30kVinPoMtoIPeVaKLEgLpVkvg=

--- a/list_box.go
+++ b/list_box.go
@@ -44,6 +44,10 @@ func NewListBox(contentView *ContentBox, notes *Notes) *ListBox {
 	box.SetSelectedFocusOnly(false)
 
 	box.SetChangedFunc(func(index int, mainText, secondaryText string, shortcut rune) {
+		if box.contentView.HasFocus() {
+			box.contentView.RefreshFile()
+			return
+		}
 		if (!box.HasFocus() && notes.LastQuery == "") || len(notes.LastSearchResults) == 0 {
 			box.contentView.Clear()
 		} else {
@@ -87,7 +91,7 @@ func (b *ListBox) SearchResultsUpdate(notes *Notes) {
 
 	b.SetSelectedFocusOnly(emptyQuery)
 
-	if len(lastResult) == 0 {
+	if len(lastResult) == 0 && !b.contentView.HasFocus() {
 		b.contentView.Clear()
 	}
 

--- a/notes.go
+++ b/notes.go
@@ -123,11 +123,7 @@ func (n *Notes) CreateNote(name string) (*FileRef, error) {
 }
 
 func (n *Notes) RegisterObservers(obs ...Observer) {
-	if n.observers != nil {
-		n.observers = obs
-	} else {
-		n.observers = append(n.observers, obs...)
-	}
+	n.observers = obs
 }
 
 func (n *Notes) Notify() {

--- a/tui_harness_test.go
+++ b/tui_harness_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+
+package nve
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// binaryPath is set once by TestMain and reused by all TUI tests.
+var binaryPath string
+
+func TestMain(m *testing.M) {
+	// Build the binary once for all integration tests.
+	tmp, err := os.MkdirTemp("", "nve-tui-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmp)
+
+	binaryPath = filepath.Join(tmp, "nve")
+	cmd := exec.Command("go", "build", "--tags=fts5", "-o", binaryPath, "./cmd/main.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+// TUIHarness drives the real nve binary inside a tmux session for functional testing.
+type TUIHarness struct {
+	t       *testing.T
+	dir     string // temp dir where the app runs
+	session string // tmux session name
+	mu      sync.Mutex
+}
+
+// NewTUIHarness builds and launches nve in a tmux session.
+// seedFiles is a map of filename -> content to pre-populate the test directory.
+func NewTUIHarness(t *testing.T, seedFiles map[string]string) *TUIHarness {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	// Write seed files
+	for name, content := range seedFiles {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatalf("failed to create parent dir for %s: %v", name, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write seed file %s: %v", name, err)
+		}
+	}
+
+	// Remove stale DB/log files
+	os.Remove(filepath.Join(dir, "nve.db"))
+	os.Remove(filepath.Join(dir, "nve-debug.log"))
+
+	// Use test name as tmux session name (sanitized)
+	session := strings.ReplaceAll(t.Name(), "/", "-")
+
+	h := &TUIHarness{
+		t:       t,
+		dir:     dir,
+		session: session,
+	}
+
+	// Kill any stale session with the same name
+	exec.Command("tmux", "kill-session", "-t", session).Run()
+
+	// Launch tmux session running nve
+	launchCmd := fmt.Sprintf("cd %s && %s", h.dir, binaryPath)
+	cmd := exec.Command("tmux", "new-session", "-d", "-s", session, "-x", "120", "-y", "30", launchCmd)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to start tmux session: %v\n%s", err, out)
+	}
+
+	// Wait for app to be ready (Search Box title visible)
+	h.WaitFor(func(screen string) bool {
+		return strings.Contains(screen, "Search Box")
+	}, 10*time.Second)
+
+	t.Cleanup(h.Cleanup)
+
+	return h
+}
+
+// SendKeys sends each key string to the tmux session with a pause between them.
+func (h *TUIHarness) SendKeys(keys ...string) {
+	h.t.Helper()
+	for _, key := range keys {
+		cmd := exec.Command("tmux", "send-keys", "-t", h.session, key)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			h.t.Fatalf("SendKeys(%q) failed: %v\n%s", key, err, out)
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+}
+
+// Capture returns the current tmux pane content.
+func (h *TUIHarness) Capture() string {
+	h.t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	cmd := exec.Command("tmux", "capture-pane", "-t", h.session, "-p")
+	out, err := cmd.Output()
+	if err != nil {
+		h.t.Fatalf("Capture failed: %v", err)
+	}
+	return string(out)
+}
+
+// WaitFor polls the screen every 200ms until predicate returns true or timeout is reached.
+// Returns the final captured screen. Fails the test on timeout.
+func (h *TUIHarness) WaitFor(predicate func(screen string) bool, timeout time.Duration) string {
+	h.t.Helper()
+	deadline := time.Now().Add(timeout)
+	var screen string
+	for time.Now().Before(deadline) {
+		screen = h.Capture()
+		if predicate(screen) {
+			return screen
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	h.t.Logf("WaitFor timeout — final screen:\n%s", screen)
+	h.t.Fatalf("WaitFor timed out after %v", timeout)
+	return screen
+}
+
+// WriteFile writes a file into the test directory (simulates external edit).
+func (h *TUIHarness) WriteFile(name, content string) {
+	h.t.Helper()
+	path := filepath.Join(h.dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		h.t.Fatalf("WriteFile mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		h.t.Fatalf("WriteFile failed: %v", err)
+	}
+}
+
+// ReadFile reads a file from the test directory.
+func (h *TUIHarness) ReadFile(name string) string {
+	h.t.Helper()
+	data, err := os.ReadFile(filepath.Join(h.dir, name))
+	if err != nil {
+		h.t.Fatalf("ReadFile(%s) failed: %v", name, err)
+	}
+	return string(data)
+}
+
+// RemoveFile deletes a file from the test directory.
+func (h *TUIHarness) RemoveFile(name string) {
+	h.t.Helper()
+	if err := os.Remove(filepath.Join(h.dir, name)); err != nil {
+		h.t.Fatalf("RemoveFile(%s) failed: %v", name, err)
+	}
+}
+
+// Snapshot captures and logs the screen with a label (useful for debugging mid-test).
+func (h *TUIHarness) Snapshot(label string) {
+	h.t.Helper()
+	screen := h.Capture()
+	h.t.Logf("=== Snapshot [%s] ===\n%s", label, screen)
+}
+
+// Cleanup kills the tmux session. On test failure, logs the final screen and debug log.
+func (h *TUIHarness) Cleanup() {
+	if h.t.Failed() {
+		// Log final screen
+		if screen, err := exec.Command("tmux", "capture-pane", "-t", h.session, "-p").Output(); err == nil {
+			h.t.Logf("=== Final screen on failure ===\n%s", screen)
+		}
+		// Log debug log contents
+		logPath := filepath.Join(h.dir, "nve-debug.log")
+		if data, err := os.ReadFile(logPath); err == nil {
+			h.t.Logf("=== nve-debug.log ===\n%s", string(data))
+		}
+	}
+	exec.Command("tmux", "kill-session", "-t", h.session).Run()
+}

--- a/tui_harness_test.go
+++ b/tui_harness_test.go
@@ -63,10 +63,6 @@ func NewTUIHarness(t *testing.T, seedFiles map[string]string) *TUIHarness {
 		}
 	}
 
-	// Remove stale DB/log files
-	os.Remove(filepath.Join(dir, "nve.db"))
-	os.Remove(filepath.Join(dir, "nve-debug.log"))
-
 	// Use test name as tmux session name (sanitized)
 	session := strings.ReplaceAll(t.Name(), "/", "-")
 

--- a/tui_test.go
+++ b/tui_test.go
@@ -1,0 +1,169 @@
+//go:build integration
+
+package nve
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTUI_AppStartsWithFiles(t *testing.T) {
+	h := NewTUIHarness(t, map[string]string{
+		"alpha.md": "Alpha content here",
+		"beta.md":  "Beta content here",
+	})
+
+	screen := h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "alpha") && strings.Contains(s, "beta")
+	}, 5*time.Second)
+
+	if !strings.Contains(screen, "alpha") {
+		t.Errorf("expected 'alpha' in list, got:\n%s", screen)
+	}
+	if !strings.Contains(screen, "beta") {
+		t.Errorf("expected 'beta' in list, got:\n%s", screen)
+	}
+}
+
+func TestTUI_EditAndSave(t *testing.T) {
+	h := NewTUIHarness(t, map[string]string{
+		"notes.md": "original content",
+	})
+
+	// Wait for file to appear in list
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "notes")
+	}, 5*time.Second)
+
+	// Navigate: Down arrow moves to ListBox with selection, Enter opens in ContentBox
+	h.SendKeys("Down", "Enter")
+
+	// Wait for ContentBox to show the file content
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "original content")
+	}, 3*time.Second)
+
+	// Type some text — cursor starts at beginning, so just type directly
+	h.SendKeys("h", "i")
+
+	// Wait for debounced save (300ms save + buffer)
+	time.Sleep(1 * time.Second)
+
+	// Verify text persisted to disk
+	content := h.ReadFile("notes.md")
+	if !strings.Contains(content, "hi") {
+		t.Errorf("expected 'hi' in saved file, got: %s", content)
+	}
+
+	// Escape back to SearchBox, then re-open the file
+	h.SendKeys("Escape")
+	time.Sleep(500 * time.Millisecond)
+	h.SendKeys("Down", "Enter")
+
+	// Verify content still has our edit
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "hi")
+	}, 3*time.Second)
+}
+
+func TestTUI_ExternalFileCreate(t *testing.T) {
+	h := NewTUIHarness(t, map[string]string{
+		"existing.md": "already here",
+	})
+
+	// Wait for initial file
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "existing")
+	}, 5*time.Second)
+
+	// Create a new file externally
+	h.WriteFile("newfile.md", "externally created content")
+
+	// Wait for it to appear in the list (watcher debounce is 500ms)
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "newfile")
+	}, 5*time.Second)
+}
+
+func TestTUI_ExternalFileDelete(t *testing.T) {
+	h := NewTUIHarness(t, map[string]string{
+		"keeper.md":  "I stay",
+		"goner.md":   "I go away",
+	})
+
+	// Wait for both files
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "keeper") && strings.Contains(s, "goner")
+	}, 5*time.Second)
+
+	// Delete the file externally
+	h.RemoveFile("goner.md")
+
+	// Wait for it to disappear from the list
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "keeper") && !strings.Contains(s, "goner")
+	}, 5*time.Second)
+}
+
+func TestTUI_ExternalEditWhileViewing(t *testing.T) {
+	h := NewTUIHarness(t, map[string]string{
+		"watched.md": "version one",
+	})
+
+	// Wait for file in list
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "watched")
+	}, 5*time.Second)
+
+	// Open the file in ContentBox
+	h.SendKeys("Down", "Enter")
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "version one")
+	}, 3*time.Second)
+
+	// Externally overwrite the file
+	h.WriteFile("watched.md", "version two")
+
+	// Escape to SearchBox (triggers flushRefresh on blur), then re-open
+	h.SendKeys("Escape")
+	time.Sleep(1 * time.Second) // wait for watcher debounce + refresh
+	h.SendKeys("Down", "Enter")
+
+	// Verify new content is shown
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "version two")
+	}, 5*time.Second)
+}
+
+func TestTUI_SelfEditNoContentClearing(t *testing.T) {
+	h := NewTUIHarness(t, map[string]string{
+		"stable.md": "initial text",
+	})
+
+	// Wait for file in list
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "stable")
+	}, 5*time.Second)
+
+	// Open the file: Down arrow selects in ListBox, Enter opens ContentBox
+	h.SendKeys("Down", "Enter")
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "initial text")
+	}, 3*time.Second)
+
+	// Type additional text (cursor starts at beginning)
+	h.SendKeys("x", "y", "z")
+
+	// Wait for save to complete (debounce 300ms + watcher 500ms + buffer)
+	time.Sleep(2 * time.Second)
+
+	// Verify ContentBox still shows both the original and new text
+	screen := h.Capture()
+	if !strings.Contains(screen, "initial text") {
+		t.Errorf("expected 'initial text' still visible, got:\n%s", screen)
+	}
+	if !strings.Contains(screen, "xyz") {
+		t.Errorf("expected 'xyz' still visible, got:\n%s", screen)
+	}
+}

--- a/tui_test.go
+++ b/tui_test.go
@@ -129,6 +129,37 @@ func TestTUI_ExternalEditWhileViewing(t *testing.T) {
 	}, 5*time.Second)
 }
 
+func TestTUI_CreateNewNote(t *testing.T) {
+	h := NewTUIHarness(t, map[string]string{
+		"existing.md": "some content",
+	})
+
+	// Wait for app to be ready with existing file
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "existing")
+	}, 5*time.Second)
+
+	// Type a name that doesn't match any file, then hit Enter
+	h.SendKeys("m", "y", "n", "e", "w", "n", "o", "t", "e", "Enter")
+
+	// Should land in ContentBox with a new empty file
+	h.WaitFor(func(s string) bool {
+		return strings.Contains(s, "mynewnote")
+	}, 5*time.Second)
+
+	// Type some content
+	h.SendKeys("h", "e", "l", "l", "o")
+
+	// Wait for save
+	time.Sleep(1 * time.Second)
+
+	// Verify the file was created on disk
+	content := h.ReadFile("mynewnote.md")
+	if !strings.Contains(content, "hello") {
+		t.Errorf("expected 'hello' in new file, got: %s", content)
+	}
+}
+
 func TestTUI_SelfEditNoContentClearing(t *testing.T) {
 	h := NewTUIHarness(t, map[string]string{
 		"stable.md": "initial text",

--- a/tui_test.go
+++ b/tui_test.go
@@ -14,16 +14,9 @@ func TestTUI_AppStartsWithFiles(t *testing.T) {
 		"beta.md":  "Beta content here",
 	})
 
-	screen := h.WaitFor(func(s string) bool {
+	h.WaitFor(func(s string) bool {
 		return strings.Contains(s, "alpha") && strings.Contains(s, "beta")
 	}, 5*time.Second)
-
-	if !strings.Contains(screen, "alpha") {
-		t.Errorf("expected 'alpha' in list, got:\n%s", screen)
-	}
-	if !strings.Contains(screen, "beta") {
-		t.Errorf("expected 'beta' in list, got:\n%s", screen)
-	}
 }
 
 func TestTUI_EditAndSave(t *testing.T) {

--- a/watcher.go
+++ b/watcher.go
@@ -23,15 +23,8 @@ func (n *Notes) StartWatching(drawFunc func(func())) error {
 	n.watcher = watcher
 	n.drawFunc = drawFunc
 
-	// Add root directory
-	if err := watcher.Add(n.config.Filepath); err != nil {
-		watcher.Close()
-		n.watcher = nil
-		return err
-	}
-
-	// Add subdirectories
-	filepath.Walk(n.config.Filepath, func(path string, info os.FileInfo, err error) error {
+	// Watch root and all subdirectories
+	if err := filepath.Walk(n.config.Filepath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -41,7 +34,11 @@ func (n *Notes) StartWatching(drawFunc func(func())) error {
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		watcher.Close()
+		n.watcher = nil
+		return err
+	}
 
 	go n.watchLoop(watcher)
 

--- a/watcher.go
+++ b/watcher.go
@@ -1,0 +1,110 @@
+package nve
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/bep/debounce"
+	"github.com/fsnotify/fsnotify"
+)
+
+// StartWatching begins monitoring the notes directory for filesystem changes.
+// drawFunc is used to marshal UI updates onto the tview event loop.
+// If watching fails to start, a warning is logged but the error is returned
+// so the caller can decide how to handle it.
+func (n *Notes) StartWatching(drawFunc func(func())) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	n.watcher = watcher
+	n.drawFunc = drawFunc
+
+	// Add root directory
+	if err := watcher.Add(n.config.Filepath); err != nil {
+		watcher.Close()
+		n.watcher = nil
+		return err
+	}
+
+	// Add subdirectories
+	filepath.Walk(n.config.Filepath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			if watchErr := watcher.Add(path); watchErr != nil {
+				log.Printf("[WARN] watcher: could not watch %s: %v", path, watchErr)
+			}
+		}
+		return nil
+	})
+
+	go n.watchLoop(watcher)
+
+	log.Printf("[INFO] watcher: started monitoring %s", n.config.Filepath)
+	return nil
+}
+
+// StopWatching stops the filesystem watcher.
+func (n *Notes) StopWatching() {
+	if n.watcher != nil {
+		n.watcher.Close()
+		n.watcher = nil
+		log.Printf("[INFO] watcher: stopped")
+	}
+}
+
+func (n *Notes) watchLoop(watcher *fsnotify.Watcher) {
+	debounced := debounce.New(500 * time.Millisecond)
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+
+			// Watch newly created subdirectories
+			if event.Has(fsnotify.Create) {
+				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+					if err := watcher.Add(event.Name); err != nil {
+						log.Printf("[WARN] watcher: could not watch new dir %s: %v", event.Name, err)
+					}
+				}
+			}
+
+			// Filter to supported file types
+			ext := filepath.Ext(event.Name)
+			if !SUPPORTED_FILETYPES[ext] {
+				continue
+			}
+
+			log.Printf("[DEBUG] watcher: event %s on %s", event.Op, event.Name)
+			debounced(n.handleWatcherRefresh)
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("[ERROR] watcher: %v", err)
+		}
+	}
+}
+
+func (n *Notes) handleWatcherRefresh() {
+	changed, err := n.Refresh()
+	if err != nil {
+		log.Printf("[ERROR] watcher: refresh failed: %v", err)
+		return
+	}
+
+	if changed && n.drawFunc != nil {
+		n.drawFunc(func() {
+			n.Search(n.LastQuery)
+		})
+	}
+}

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,0 +1,125 @@
+package nve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupWatcherTest(t *testing.T) (*Notes, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	n := NewNotes(NotesConfig{
+		Filepath: dir,
+		DBPath:   dbPath,
+	})
+
+	return n, dir
+}
+
+func TestWatcher_CreateFile(t *testing.T) {
+	n, dir := setupWatcherTest(t)
+
+	refreshed := make(chan struct{}, 1)
+	err := n.StartWatching(func(f func()) {
+		f()
+		select {
+		case refreshed <- struct{}{}:
+		default:
+		}
+	})
+	require.NoError(t, err)
+	defer n.StopWatching()
+
+	// Create a new .md file
+	testFile := filepath.Join(dir, "new_note.md")
+	require.NoError(t, os.WriteFile(testFile, []byte("hello watcher"), 0644))
+
+	// Wait for the debounced refresh
+	select {
+	case <-refreshed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for watcher refresh")
+	}
+
+	// Verify the file is in the DB
+	results, err := n.db.Search("hello watcher")
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, testFile, results[0].Filename)
+}
+
+func TestWatcher_DeleteFile(t *testing.T) {
+	n, dir := setupWatcherTest(t)
+
+	// Create a file first and refresh to index it
+	testFile := filepath.Join(dir, "to_delete.md")
+	require.NoError(t, os.WriteFile(testFile, []byte("delete me"), 0644))
+	_, err := n.Refresh()
+	require.NoError(t, err)
+
+	// Verify it's indexed
+	results, err := n.db.Search("delete me")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	refreshed := make(chan struct{}, 1)
+	err = n.StartWatching(func(f func()) {
+		f()
+		select {
+		case refreshed <- struct{}{}:
+		default:
+		}
+	})
+	require.NoError(t, err)
+	defer n.StopWatching()
+
+	// Delete the file
+	require.NoError(t, os.Remove(testFile))
+
+	// Wait for the debounced refresh
+	select {
+	case <-refreshed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for watcher refresh")
+	}
+
+	// Verify it's been pruned from the DB
+	results, err = n.db.Search("delete me")
+	require.NoError(t, err)
+	assert.Len(t, results, 0)
+}
+
+func TestWatcher_IgnoresUnsupportedTypes(t *testing.T) {
+	n, dir := setupWatcherTest(t)
+
+	refreshed := make(chan struct{}, 1)
+	err := n.StartWatching(func(f func()) {
+		f()
+		select {
+		case refreshed <- struct{}{}:
+		default:
+		}
+	})
+	require.NoError(t, err)
+	defer n.StopWatching()
+
+	// Create an unsupported file type
+	pngFile := filepath.Join(dir, "image.png")
+	require.NoError(t, os.WriteFile(pngFile, []byte("not a real png"), 0644))
+
+	// The watcher should filter this out; wait briefly to confirm no refresh
+	select {
+	case <-refreshed:
+		t.Fatal("watcher should not have triggered refresh for .png file")
+	case <-time.After(1 * time.Second):
+		// Expected: no refresh triggered
+	}
+}


### PR DESCRIPTION
This changes uses `fsnotify` to watch the notes directory for any file operations, with debounced DB refresh and UI updates.

Other changes
* Adds a new TUI test harness, and new integration tests that assert end to end behavior (edit/save, creating new notes)
* Fixes race condition when using the search box to create a new note
* Simplifies some code paths
* New make target (`make test-tui`) that runs integration tests.

## Test plan
- [x] `make test` — unit tests pass
- [x] `make test-tui` — all 7 TUI integration tests pass
- [x] Manual: type a non-matching name in SearchBox, hit Enter → new file created, focus lands in ContentBox
- [x] Manual: edit a file externally while viewing it → Escape + re-open shows new content
