### PR TITLE
Markdown syntax highlighting in content pane

### DIFF
--- a/content_box.go
+++ b/content_box.go
@@ -2,6 +2,7 @@ package nve
 
 import (
 	"log"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode"
@@ -88,25 +89,27 @@ func (b *ContentBox) SetSearchQuery(query string) {
 	b.searchQuery = query
 }
 
-// Draw renders the text area and then highlights any occurrences of the search query.
+// Draw renders the text area, applies markdown syntax highlighting for .md files,
+// and then highlights any occurrences of the search query.
 func (b *ContentBox) Draw(screen tcell.Screen) {
 	b.TextArea.Draw(screen)
+
+	x, y, width, height := b.GetInnerRect()
+
+	// Apply markdown highlighting before search highlighting
+	if b.isMarkdown() {
+		inCodeBlock := b.codeBlockStateAtVisibleTop(screen, x, y, width)
+		applyMarkdownHighlighting(screen, x, y, width, height, inCodeBlock)
+	}
 
 	if b.searchQuery == "" {
 		return
 	}
 
-	x, y, width, height := b.GetInnerRect()
 	query := strings.ToLower(b.searchQuery)
 
 	for row := y; row < y+height; row++ {
-		// Build the visible line from screen cells
-		runes := make([]rune, width)
-		for col := 0; col < width; col++ {
-			mainc, _, _, _ := screen.GetContent(x+col, row)
-			runes[col] = mainc
-		}
-		line := strings.ToLower(string(runes))
+		line := strings.ToLower(extractLine(screen, x, row, width))
 
 		// Find all occurrences of the query in this line
 		offset := 0
@@ -124,6 +127,35 @@ func (b *ContentBox) Draw(screen tcell.Screen) {
 			offset = matchStart + len(query)
 		}
 	}
+}
+
+// isMarkdown returns true if the current file is a markdown file.
+func (b *ContentBox) isMarkdown() bool {
+	if b.currentFile == nil {
+		return false
+	}
+	ext := filepath.Ext(b.currentFile.Filename)
+	return ext == ".md" || ext == ".mdown"
+}
+
+// codeBlockStateAtVisibleTop determines whether the first visible row
+// is inside a code block by matching it to the source text and counting
+// code fences above it.
+func (b *ContentBox) codeBlockStateAtVisibleTop(screen tcell.Screen, x, y, width int) bool {
+	firstLine := strings.TrimRight(extractLine(screen, x, y, width), " \x00")
+	if firstLine == "" {
+		return false
+	}
+
+	fullText := b.GetText()
+	idx := strings.Index(fullText, firstLine)
+	if idx <= 0 {
+		return false
+	}
+
+	// Count code fences in text before the visible area
+	preceding := fullText[:idx]
+	return countCodeFences(preceding, strings.Count(preceding, "\n")+1)%2 == 1
 }
 
 // InputHandler overrides default handling to switch focus away from search box when necessary.

--- a/content_box.go
+++ b/content_box.go
@@ -98,7 +98,7 @@ func (b *ContentBox) Draw(screen tcell.Screen) {
 
 	// Apply markdown highlighting before search highlighting
 	if b.isMarkdown() {
-		inCodeBlock := b.codeBlockStateAtVisibleTop(screen, x, y, width)
+		inCodeBlock := b.codeBlockStateAtVisibleTop()
 		applyMarkdownHighlighting(screen, x, y, width, height, inCodeBlock, Zenburn)
 	}
 
@@ -139,23 +139,14 @@ func (b *ContentBox) isMarkdown() bool {
 }
 
 // codeBlockStateAtVisibleTop determines whether the first visible row
-// is inside a code block by matching it to the source text and counting
-// code fences above it.
-func (b *ContentBox) codeBlockStateAtVisibleTop(screen tcell.Screen, x, y, width int) bool {
-	firstLine := strings.TrimRight(extractLine(screen, x, y, width), " \x00")
-	if firstLine == "" {
+// is inside a code block by using the TextArea's scroll offset to count
+// code fences above the visible area.
+func (b *ContentBox) codeBlockStateAtVisibleTop() bool {
+	topRow, _ := b.GetOffset()
+	if topRow <= 0 {
 		return false
 	}
-
-	fullText := b.GetText()
-	idx := strings.Index(fullText, firstLine)
-	if idx <= 0 {
-		return false
-	}
-
-	// Count code fences in text before the visible area
-	preceding := fullText[:idx]
-	return countCodeFences(preceding, strings.Count(preceding, "\n")+1)%2 == 1
+	return countCodeFences(b.GetText(), topRow)%2 == 1
 }
 
 // InputHandler overrides default handling to switch focus away from search box when necessary.

--- a/content_box.go
+++ b/content_box.go
@@ -99,7 +99,7 @@ func (b *ContentBox) Draw(screen tcell.Screen) {
 	// Apply markdown highlighting before search highlighting
 	if b.isMarkdown() {
 		inCodeBlock := b.codeBlockStateAtVisibleTop(screen, x, y, width)
-		applyMarkdownHighlighting(screen, x, y, width, height, inCodeBlock)
+		applyMarkdownHighlighting(screen, x, y, width, height, inCodeBlock, Zenburn)
 	}
 
 	if b.searchQuery == "" {

--- a/markdown.go
+++ b/markdown.go
@@ -6,23 +6,37 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
-// Zenburn-inspired markdown color palette (256-color terminal palette indices).
-var (
-	mdHeading1Color   = tcell.PaletteColor(187) // pale yellow
-	mdHeading2Color   = tcell.PaletteColor(186) // olive-yellow
-	mdHeading3Color   = tcell.PaletteColor(150) // muted green
-	mdBoldColor       = tcell.PaletteColor(253) // light gray
-	mdItalicColor     = tcell.PaletteColor(253) // light gray
-	mdInlineCodeColor = tcell.PaletteColor(223) // peachy/tan
-	mdLinkTextColor   = tcell.PaletteColor(174) // muted rose
-	mdLinkURLColor    = tcell.PaletteColor(67)  // muted blue
-	mdListMarkerColor = tcell.PaletteColor(187) // pale yellow
-	mdBlockquoteColor = tcell.PaletteColor(108) // sage green
-)
+// MarkdownStyle defines the color palette for markdown syntax highlighting.
+type MarkdownStyle struct {
+	Heading1   tcell.Color
+	Heading2   tcell.Color
+	Heading3   tcell.Color
+	Bold       tcell.Color
+	Italic     tcell.Color
+	InlineCode tcell.Color
+	LinkText   tcell.Color
+	LinkURL    tcell.Color
+	ListMarker tcell.Color
+	Blockquote tcell.Color
+}
+
+// Zenburn is a low-contrast color scheme using muted, earthy tones (256-color palette).
+var Zenburn = MarkdownStyle{
+	Heading1:   tcell.PaletteColor(187), // pale yellow
+	Heading2:   tcell.PaletteColor(186), // olive-yellow
+	Heading3:   tcell.PaletteColor(150), // muted green
+	Bold:       tcell.PaletteColor(253), // light gray
+	Italic:     tcell.PaletteColor(253), // light gray
+	InlineCode: tcell.PaletteColor(223), // peachy/tan
+	LinkText:   tcell.PaletteColor(174), // muted rose
+	LinkURL:    tcell.PaletteColor(67),  // muted blue
+	ListMarker: tcell.PaletteColor(187), // pale yellow
+	Blockquote: tcell.PaletteColor(108), // sage green
+}
 
 // applyMarkdownHighlighting processes visible screen rows and applies
-// zenburn-style coloring to markdown syntax elements.
-func applyMarkdownHighlighting(screen tcell.Screen, x, y, width, height int, inCodeBlock bool) {
+// style-based coloring to markdown syntax elements.
+func applyMarkdownHighlighting(screen tcell.Screen, x, y, width, height int, inCodeBlock bool, style MarkdownStyle) {
 	for row := 0; row < height; row++ {
 		line := extractLine(screen, x, y+row, width)
 		trimmed := strings.TrimLeft(line, " ")
@@ -30,61 +44,61 @@ func applyMarkdownHighlighting(screen tcell.Screen, x, y, width, height int, inC
 
 		// Code fence toggle
 		if strings.HasPrefix(trimmed, "```") {
-			colorRange(screen, x, y+row, 0, width, mdInlineCodeColor, false, false)
+			colorRange(screen, x, y+row, 0, width, style.InlineCode, false, false)
 			inCodeBlock = !inCodeBlock
 			continue
 		}
 
 		// Inside code block
 		if inCodeBlock {
-			colorRange(screen, x, y+row, 0, width, mdInlineCodeColor, false, false)
+			colorRange(screen, x, y+row, 0, width, style.InlineCode, false, false)
 			continue
 		}
 
 		// Headings
 		if strings.HasPrefix(trimmed, "# ") {
-			colorRange(screen, x, y+row, 0, width, mdHeading1Color, true, false)
+			colorRange(screen, x, y+row, 0, width, style.Heading1, true, false)
 			continue
 		}
 		if strings.HasPrefix(trimmed, "## ") {
-			colorRange(screen, x, y+row, 0, width, mdHeading2Color, true, false)
+			colorRange(screen, x, y+row, 0, width, style.Heading2, true, false)
 			continue
 		}
 		if strings.HasPrefix(trimmed, "### ") || strings.HasPrefix(trimmed, "#### ") ||
 			strings.HasPrefix(trimmed, "##### ") || strings.HasPrefix(trimmed, "###### ") {
-			colorRange(screen, x, y+row, 0, width, mdHeading3Color, true, false)
+			colorRange(screen, x, y+row, 0, width, style.Heading3, true, false)
 			continue
 		}
 
 		// Blockquote
 		if strings.HasPrefix(trimmed, "> ") || trimmed == ">" {
-			colorRange(screen, x, y+row, 0, width, mdBlockquoteColor, false, false)
+			colorRange(screen, x, y+row, 0, width, style.Blockquote, false, false)
 			continue
 		}
 
 		// List markers: "- " or "* " at line start (with optional indent)
 		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
-			colorRange(screen, x, y+row, indent, indent+2, mdListMarkerColor, true, false)
+			colorRange(screen, x, y+row, indent, indent+2, style.ListMarker, true, false)
 		}
 
 		// Inline patterns
-		applyInlineHighlighting(screen, x, y+row, line)
+		applyInlineHighlighting(screen, x, y+row, line, style)
 	}
 }
 
 // applyInlineHighlighting applies bold, italic, inline code, and link styles within a line.
-func applyInlineHighlighting(screen tcell.Screen, x, row int, line string) {
+func applyInlineHighlighting(screen tcell.Screen, x, row int, line string, style MarkdownStyle) {
 	// Inline code: `text`
-	highlightDelimited(screen, x, row, line, "`", "`", mdInlineCodeColor, false, false)
+	highlightDelimited(screen, x, row, line, "`", "`", style.InlineCode, false, false)
 
 	// Bold: **text**
-	highlightDelimited(screen, x, row, line, "**", "**", mdBoldColor, true, false)
+	highlightDelimited(screen, x, row, line, "**", "**", style.Bold, true, false)
 
 	// Italic: *text* (skip if preceded by *)
-	applyItalicHighlighting(screen, x, row, line)
+	applyItalicHighlighting(screen, x, row, line, style)
 
 	// Links: [text](url)
-	applyLinkHighlighting(screen, x, row, line)
+	applyLinkHighlighting(screen, x, row, line, style)
 }
 
 // highlightDelimited finds pairs of start/end delimiters and colors the content between them.
@@ -113,7 +127,7 @@ func highlightDelimited(screen tcell.Screen, x, row int, line, startDelim, endDe
 }
 
 // applyItalicHighlighting handles *text* while avoiding **bold** markers.
-func applyItalicHighlighting(screen tcell.Screen, x, row int, line string) {
+func applyItalicHighlighting(screen tcell.Screen, x, row int, line string, style MarkdownStyle) {
 	offset := 0
 	for {
 		start := strings.Index(line[offset:], "*")
@@ -149,13 +163,13 @@ func applyItalicHighlighting(screen tcell.Screen, x, row int, line string) {
 			continue
 		}
 
-		colorRange(screen, x, row, start, end+1, mdItalicColor, false, true)
+		colorRange(screen, x, row, start, end+1, style.Italic, false, true)
 		offset = end + 1
 	}
 }
 
 // applyLinkHighlighting handles [text](url) patterns.
-func applyLinkHighlighting(screen tcell.Screen, x, row int, line string) {
+func applyLinkHighlighting(screen tcell.Screen, x, row int, line string, style MarkdownStyle) {
 	offset := 0
 	for {
 		bracketOpen := strings.Index(line[offset:], "[")
@@ -177,10 +191,10 @@ func applyLinkHighlighting(screen tcell.Screen, x, row int, line string) {
 		parenClose += bracketClose + 2
 
 		// [text] in rose
-		colorRange(screen, x, row, bracketOpen, bracketClose+1, mdLinkTextColor, false, false)
+		colorRange(screen, x, row, bracketOpen, bracketClose+1, style.LinkText, false, false)
 		// ](url) in blue underline
 		modifyStyleRange(screen, x, row, bracketClose+1, parenClose+1, func(s tcell.Style) tcell.Style {
-			return s.Foreground(mdLinkURLColor).Underline(true)
+			return s.Foreground(style.LinkURL).Underline(true)
 		})
 
 		offset = parenClose + 1

--- a/markdown.go
+++ b/markdown.go
@@ -1,0 +1,236 @@
+package nve
+
+import (
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// Zenburn-inspired markdown color palette (256-color terminal palette indices).
+var (
+	mdHeading1Color   = tcell.PaletteColor(187) // pale yellow
+	mdHeading2Color   = tcell.PaletteColor(186) // olive-yellow
+	mdHeading3Color   = tcell.PaletteColor(150) // muted green
+	mdBoldColor       = tcell.PaletteColor(253) // light gray
+	mdItalicColor     = tcell.PaletteColor(253) // light gray
+	mdInlineCodeColor = tcell.PaletteColor(223) // peachy/tan
+	mdLinkTextColor   = tcell.PaletteColor(174) // muted rose
+	mdLinkURLColor    = tcell.PaletteColor(67)  // muted blue
+	mdListMarkerColor = tcell.PaletteColor(187) // pale yellow
+	mdBlockquoteColor = tcell.PaletteColor(108) // sage green
+)
+
+// applyMarkdownHighlighting processes visible screen rows and applies
+// zenburn-style coloring to markdown syntax elements.
+func applyMarkdownHighlighting(screen tcell.Screen, x, y, width, height int, inCodeBlock bool) {
+	for row := 0; row < height; row++ {
+		line := extractLine(screen, x, y+row, width)
+		trimmed := strings.TrimLeft(line, " ")
+		indent := len(line) - len(trimmed)
+
+		// Code fence toggle
+		if strings.HasPrefix(trimmed, "```") {
+			colorRange(screen, x, y+row, 0, width, mdInlineCodeColor, false, false)
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+
+		// Inside code block
+		if inCodeBlock {
+			colorRange(screen, x, y+row, 0, width, mdInlineCodeColor, false, false)
+			continue
+		}
+
+		// Headings
+		if strings.HasPrefix(trimmed, "# ") {
+			colorRange(screen, x, y+row, 0, width, mdHeading1Color, true, false)
+			continue
+		}
+		if strings.HasPrefix(trimmed, "## ") {
+			colorRange(screen, x, y+row, 0, width, mdHeading2Color, true, false)
+			continue
+		}
+		if strings.HasPrefix(trimmed, "### ") || strings.HasPrefix(trimmed, "#### ") ||
+			strings.HasPrefix(trimmed, "##### ") || strings.HasPrefix(trimmed, "###### ") {
+			colorRange(screen, x, y+row, 0, width, mdHeading3Color, true, false)
+			continue
+		}
+
+		// Blockquote
+		if strings.HasPrefix(trimmed, "> ") || trimmed == ">" {
+			colorRange(screen, x, y+row, 0, width, mdBlockquoteColor, false, false)
+			continue
+		}
+
+		// List markers: "- " or "* " at line start (with optional indent)
+		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
+			colorRange(screen, x, y+row, indent, indent+2, mdListMarkerColor, true, false)
+		}
+
+		// Inline patterns
+		applyInlineHighlighting(screen, x, y+row, line)
+	}
+}
+
+// applyInlineHighlighting applies bold, italic, inline code, and link styles within a line.
+func applyInlineHighlighting(screen tcell.Screen, x, row int, line string) {
+	// Inline code: `text`
+	highlightDelimited(screen, x, row, line, "`", "`", mdInlineCodeColor, false, false)
+
+	// Bold: **text**
+	highlightDelimited(screen, x, row, line, "**", "**", mdBoldColor, true, false)
+
+	// Italic: *text* (skip if preceded by *)
+	applyItalicHighlighting(screen, x, row, line)
+
+	// Links: [text](url)
+	applyLinkHighlighting(screen, x, row, line)
+}
+
+// highlightDelimited finds pairs of start/end delimiters and colors the content between them.
+func highlightDelimited(screen tcell.Screen, x, row int, line, startDelim, endDelim string, fg tcell.Color, bold, italic bool) {
+	offset := 0
+	for {
+		start := strings.Index(line[offset:], startDelim)
+		if start < 0 {
+			break
+		}
+		start += offset
+		searchFrom := start + len(startDelim)
+		if searchFrom >= len(line) {
+			break
+		}
+		end := strings.Index(line[searchFrom:], endDelim)
+		if end < 0 {
+			break
+		}
+		end += searchFrom
+
+		// Color the delimiters and content
+		colorRange(screen, x, row, start, end+len(endDelim), fg, bold, italic)
+		offset = end + len(endDelim)
+	}
+}
+
+// applyItalicHighlighting handles *text* while avoiding **bold** markers.
+func applyItalicHighlighting(screen tcell.Screen, x, row int, line string) {
+	offset := 0
+	for {
+		start := strings.Index(line[offset:], "*")
+		if start < 0 {
+			break
+		}
+		start += offset
+
+		// Skip bold markers (**)
+		if start+1 < len(line) && line[start+1] == '*' {
+			offset = start + 2
+			continue
+		}
+		// Skip if preceded by * (end of bold)
+		if start > 0 && line[start-1] == '*' {
+			offset = start + 1
+			continue
+		}
+
+		searchFrom := start + 1
+		if searchFrom >= len(line) {
+			break
+		}
+		end := strings.Index(line[searchFrom:], "*")
+		if end < 0 {
+			break
+		}
+		end += searchFrom
+
+		// Skip if followed by * (start of bold)
+		if end+1 < len(line) && line[end+1] == '*' {
+			offset = end + 2
+			continue
+		}
+
+		colorRange(screen, x, row, start, end+1, mdItalicColor, false, true)
+		offset = end + 1
+	}
+}
+
+// applyLinkHighlighting handles [text](url) patterns.
+func applyLinkHighlighting(screen tcell.Screen, x, row int, line string) {
+	offset := 0
+	for {
+		bracketOpen := strings.Index(line[offset:], "[")
+		if bracketOpen < 0 {
+			break
+		}
+		bracketOpen += offset
+
+		bracketClose := strings.Index(line[bracketOpen+1:], "](")
+		if bracketClose < 0 {
+			break
+		}
+		bracketClose += bracketOpen + 1
+
+		parenClose := strings.Index(line[bracketClose+2:], ")")
+		if parenClose < 0 {
+			break
+		}
+		parenClose += bracketClose + 2
+
+		// [text] in rose
+		colorRange(screen, x, row, bracketOpen, bracketClose+1, mdLinkTextColor, false, false)
+		// ](url) in blue underline
+		modifyStyleRange(screen, x, row, bracketClose+1, parenClose+1, func(s tcell.Style) tcell.Style {
+			return s.Foreground(mdLinkURLColor).Underline(true)
+		})
+
+		offset = parenClose + 1
+	}
+}
+
+// extractLine reads a row of screen cells and returns the text as a string.
+func extractLine(screen tcell.Screen, x, row, width int) string {
+	runes := make([]rune, width)
+	for col := 0; col < width; col++ {
+		mainc, _, _, _ := screen.GetContent(x+col, row)
+		runes[col] = mainc
+	}
+	return string(runes)
+}
+
+// modifyStyleRange applies a style transformation to a range of screen cells.
+func modifyStyleRange(screen tcell.Screen, x, row, from, to int, fn func(tcell.Style) tcell.Style) {
+	for col := from; col < to; col++ {
+		mainc, combc, style, _ := screen.GetContent(x+col, row)
+		screen.SetContent(x+col, row, mainc, combc, fn(style))
+	}
+}
+
+// colorRange applies foreground color and optional bold/italic to a range of screen cells.
+func colorRange(screen tcell.Screen, x, row, from, to int, fg tcell.Color, bold, italic bool) {
+	modifyStyleRange(screen, x, row, from, to, func(s tcell.Style) tcell.Style {
+		s = s.Foreground(fg)
+		if bold {
+			s = s.Bold(true)
+		}
+		if italic {
+			s = s.Italic(true)
+		}
+		return s
+	})
+}
+
+// countCodeFences counts the number of code fence (```) lines in text
+// to determine if we start inside a code block.
+func countCodeFences(text string, maxLine int) int {
+	count := 0
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if i >= maxLine {
+			break
+		}
+		if strings.HasPrefix(strings.TrimLeft(line, " "), "```") {
+			count++
+		}
+	}
+	return count
+}

--- a/markdown.go
+++ b/markdown.go
@@ -87,78 +87,106 @@ func applyMarkdownHighlighting(screen tcell.Screen, x, y, width, height int, inC
 }
 
 // applyInlineHighlighting applies bold, italic, inline code, and link styles within a line.
+// Inline code is applied last so it takes precedence (e.g., `**not bold**` stays code-styled).
+// The line is converted to []rune once so all index operations use cell coordinates.
 func applyInlineHighlighting(screen tcell.Screen, x, row int, line string, style MarkdownStyle) {
-	// Inline code: `text`
-	highlightDelimited(screen, x, row, line, "`", "`", style.InlineCode, false, false)
+	runes := []rune(line)
 
 	// Bold: **text**
-	highlightDelimited(screen, x, row, line, "**", "**", style.Bold, true, false)
+	highlightDelimited(screen, x, row, runes, "**", "**", style.Bold, true, false)
 
 	// Italic: *text* (skip if preceded by *)
-	applyItalicHighlighting(screen, x, row, line, style)
+	applyItalicHighlighting(screen, x, row, runes, style)
 
 	// Links: [text](url)
-	applyLinkHighlighting(screen, x, row, line, style)
+	applyLinkHighlighting(screen, x, row, runes, style)
+
+	// Inline code: `text` — applied last so code spans win over other styles
+	highlightDelimited(screen, x, row, runes, "`", "`", style.InlineCode, false, false)
 }
 
 // highlightDelimited finds pairs of start/end delimiters and colors the content between them.
-func highlightDelimited(screen tcell.Screen, x, row int, line, startDelim, endDelim string, fg tcell.Color, bold, italic bool) {
+// All positions are in rune (screen cell) coordinates.
+func highlightDelimited(screen tcell.Screen, x, row int, runes []rune, startDelim, endDelim string, fg tcell.Color, bold, italic bool) {
+	startRunes := []rune(startDelim)
+	endRunes := []rune(endDelim)
 	offset := 0
 	for {
-		start := strings.Index(line[offset:], startDelim)
+		start := indexRunes(runes[offset:], startRunes)
 		if start < 0 {
 			break
 		}
 		start += offset
-		searchFrom := start + len(startDelim)
-		if searchFrom >= len(line) {
+		searchFrom := start + len(startRunes)
+		if searchFrom >= len(runes) {
 			break
 		}
-		end := strings.Index(line[searchFrom:], endDelim)
+		end := indexRunes(runes[searchFrom:], endRunes)
 		if end < 0 {
 			break
 		}
 		end += searchFrom
 
 		// Color the delimiters and content
-		colorRange(screen, x, row, start, end+len(endDelim), fg, bold, italic)
-		offset = end + len(endDelim)
+		colorRange(screen, x, row, start, end+len(endRunes), fg, bold, italic)
+		offset = end + len(endRunes)
 	}
 }
 
+// indexRunes finds the first occurrence of needle in haystack, returning the rune index or -1.
+func indexRunes(haystack, needle []rune) int {
+	if len(needle) == 0 {
+		return 0
+	}
+	for i := 0; i <= len(haystack)-len(needle); i++ {
+		match := true
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
 // applyItalicHighlighting handles *text* while avoiding **bold** markers.
-func applyItalicHighlighting(screen tcell.Screen, x, row int, line string, style MarkdownStyle) {
+// All positions are in rune (screen cell) coordinates.
+func applyItalicHighlighting(screen tcell.Screen, x, row int, runes []rune, style MarkdownStyle) {
 	offset := 0
 	for {
-		start := strings.Index(line[offset:], "*")
+		start := indexRunes(runes[offset:], []rune{'*'})
 		if start < 0 {
 			break
 		}
 		start += offset
 
 		// Skip bold markers (**)
-		if start+1 < len(line) && line[start+1] == '*' {
+		if start+1 < len(runes) && runes[start+1] == '*' {
 			offset = start + 2
 			continue
 		}
 		// Skip if preceded by * (end of bold)
-		if start > 0 && line[start-1] == '*' {
+		if start > 0 && runes[start-1] == '*' {
 			offset = start + 1
 			continue
 		}
 
 		searchFrom := start + 1
-		if searchFrom >= len(line) {
+		if searchFrom >= len(runes) {
 			break
 		}
-		end := strings.Index(line[searchFrom:], "*")
+		end := indexRunes(runes[searchFrom:], []rune{'*'})
 		if end < 0 {
 			break
 		}
 		end += searchFrom
 
 		// Skip if followed by * (start of bold)
-		if end+1 < len(line) && line[end+1] == '*' {
+		if end+1 < len(runes) && runes[end+1] == '*' {
 			offset = end + 2
 			continue
 		}
@@ -169,22 +197,23 @@ func applyItalicHighlighting(screen tcell.Screen, x, row int, line string, style
 }
 
 // applyLinkHighlighting handles [text](url) patterns.
-func applyLinkHighlighting(screen tcell.Screen, x, row int, line string, style MarkdownStyle) {
+// All positions are in rune (screen cell) coordinates.
+func applyLinkHighlighting(screen tcell.Screen, x, row int, runes []rune, style MarkdownStyle) {
 	offset := 0
 	for {
-		bracketOpen := strings.Index(line[offset:], "[")
+		bracketOpen := indexRunes(runes[offset:], []rune{'['})
 		if bracketOpen < 0 {
 			break
 		}
 		bracketOpen += offset
 
-		bracketClose := strings.Index(line[bracketOpen+1:], "](")
+		bracketClose := indexRunes(runes[bracketOpen+1:], []rune{']', '('})
 		if bracketClose < 0 {
 			break
 		}
 		bracketClose += bracketOpen + 1
 
-		parenClose := strings.Index(line[bracketClose+2:], ")")
+		parenClose := indexRunes(runes[bracketClose+2:], []rune{')'})
 		if parenClose < 0 {
 			break
 		}
@@ -219,17 +248,10 @@ func modifyStyleRange(screen tcell.Screen, x, row, from, to int, fn func(tcell.S
 	}
 }
 
-// colorRange applies foreground color and optional bold/italic to a range of screen cells.
+// colorRange applies foreground color and explicit bold/italic to a range of screen cells.
 func colorRange(screen tcell.Screen, x, row, from, to int, fg tcell.Color, bold, italic bool) {
 	modifyStyleRange(screen, x, row, from, to, func(s tcell.Style) tcell.Style {
-		s = s.Foreground(fg)
-		if bold {
-			s = s.Bold(true)
-		}
-		if italic {
-			s = s.Italic(true)
-		}
-		return s
+		return s.Foreground(fg).Bold(bold).Italic(italic)
 	})
 }
 

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -188,6 +188,34 @@ func TestMarkdown_PlainTextUnchanged(t *testing.T) {
 	}
 }
 
+func TestMarkdown_InlineCodePrecedence(t *testing.T) {
+	screen := setupScreen(t, 40, 1, []string{"see `**not bold**` here"})
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false, Zenburn)
+
+	// The ** inside backticks should be styled as code, not bold
+	// "n" in "not" is at index 7
+	if fg := getFg(screen, 7, 0); fg != Zenburn.InlineCode {
+		t.Errorf("code span content should be InlineCode color, got %v, want %v", fg, Zenburn.InlineCode)
+	}
+	if isBold(screen, 7, 0) {
+		t.Error("text inside code span should not be bold")
+	}
+}
+
+func TestMarkdown_NonASCII(t *testing.T) {
+	// "café" has a multi-byte rune; bold markers should still align to screen cells
+	screen := setupScreen(t, 40, 1, []string{"café **bold** end"})
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false, Zenburn)
+
+	// "b" in "bold" is at cell index 7 ("café **" = 7 cells: c,a,f,é, ,*,*)
+	if !isBold(screen, 7, 0) {
+		t.Error("bold text after non-ASCII should have bold attribute")
+	}
+	if fg := getFg(screen, 7, 0); fg != Zenburn.Bold {
+		t.Errorf("bold color: got %v, want %v", fg, Zenburn.Bold)
+	}
+}
+
 func TestCountCodeFences(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
-// mockScreen writes text into a simulated screen so we can test highlighting.
+// setupScreen writes text into a simulated screen so we can test highlighting.
 func setupScreen(t *testing.T, width, height int, lines []string) tcell.SimulationScreen {
 	t.Helper()
 	screen := tcell.NewSimulationScreen("")
@@ -52,15 +52,15 @@ func TestMarkdown_Headings(t *testing.T) {
 		line      string
 		wantColor tcell.Color
 	}{
-		{"heading1", "# Hello World", mdHeading1Color},
-		{"heading2", "## Subheading", mdHeading2Color},
-		{"heading3", "### Third Level", mdHeading3Color},
-		{"heading4", "#### Fourth Level", mdHeading3Color},
+		{"heading1", "# Hello World", Zenburn.Heading1},
+		{"heading2", "## Subheading", Zenburn.Heading2},
+		{"heading3", "### Third Level", Zenburn.Heading3},
+		{"heading4", "#### Fourth Level", Zenburn.Heading3},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			screen := setupScreen(t, 40, 1, []string{tt.line})
-			applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+			applyMarkdownHighlighting(screen, 0, 0, 40, 1, false, Zenburn)
 			if fg := getFg(screen, 0, 0); fg != tt.wantColor {
 				t.Errorf("color: got %v, want %v", fg, tt.wantColor)
 			}
@@ -78,19 +78,19 @@ func TestMarkdown_CodeFence(t *testing.T) {
 		"```",
 	}
 	screen := setupScreen(t, 40, 3, lines)
-	applyMarkdownHighlighting(screen, 0, 0, 40, 3, false)
+	applyMarkdownHighlighting(screen, 0, 0, 40, 3, false, Zenburn)
 
 	// Fence line should be code color
-	if fg := getFg(screen, 0, 0); fg != mdInlineCodeColor {
-		t.Errorf("code fence color: got %v, want %v", fg, mdInlineCodeColor)
+	if fg := getFg(screen, 0, 0); fg != Zenburn.InlineCode {
+		t.Errorf("code fence color: got %v, want %v", fg, Zenburn.InlineCode)
 	}
 	// Content inside fence should be code color
-	if fg := getFg(screen, 0, 1); fg != mdInlineCodeColor {
-		t.Errorf("code block content color: got %v, want %v", fg, mdInlineCodeColor)
+	if fg := getFg(screen, 0, 1); fg != Zenburn.InlineCode {
+		t.Errorf("code block content color: got %v, want %v", fg, Zenburn.InlineCode)
 	}
 	// Closing fence should be code color
-	if fg := getFg(screen, 0, 2); fg != mdInlineCodeColor {
-		t.Errorf("closing fence color: got %v, want %v", fg, mdInlineCodeColor)
+	if fg := getFg(screen, 0, 2); fg != Zenburn.InlineCode {
+		t.Errorf("closing fence color: got %v, want %v", fg, Zenburn.InlineCode)
 	}
 }
 
@@ -101,30 +101,30 @@ func TestMarkdown_CodeFenceStartInside(t *testing.T) {
 	}
 	screen := setupScreen(t, 40, 2, lines)
 	// Start inside a code block (fence was above visible area)
-	applyMarkdownHighlighting(screen, 0, 0, 40, 2, true)
+	applyMarkdownHighlighting(screen, 0, 0, 40, 2, true, Zenburn)
 
 	// First line should be code color (we're inside a code block)
-	if fg := getFg(screen, 0, 0); fg != mdInlineCodeColor {
-		t.Errorf("in-code-block content: got %v, want %v", fg, mdInlineCodeColor)
+	if fg := getFg(screen, 0, 0); fg != Zenburn.InlineCode {
+		t.Errorf("in-code-block content: got %v, want %v", fg, Zenburn.InlineCode)
 	}
 }
 
 func TestMarkdown_Bold(t *testing.T) {
 	screen := setupScreen(t, 40, 1, []string{"some **bold** text"})
-	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false, Zenburn)
 
 	// "b" in "bold" is at index 7
 	if !isBold(screen, 7, 0) {
 		t.Error("bold text should have bold attribute")
 	}
-	if fg := getFg(screen, 7, 0); fg != mdBoldColor {
-		t.Errorf("bold color: got %v, want %v", fg, mdBoldColor)
+	if fg := getFg(screen, 7, 0); fg != Zenburn.Bold {
+		t.Errorf("bold color: got %v, want %v", fg, Zenburn.Bold)
 	}
 }
 
 func TestMarkdown_Italic(t *testing.T) {
 	screen := setupScreen(t, 40, 1, []string{"some *italic* text"})
-	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false, Zenburn)
 
 	// "i" in "italic" is at index 6
 	if !isItalic(screen, 6, 0) {
@@ -134,34 +134,34 @@ func TestMarkdown_Italic(t *testing.T) {
 
 func TestMarkdown_InlineCode(t *testing.T) {
 	screen := setupScreen(t, 40, 1, []string{"use `code` here"})
-	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false, Zenburn)
 
 	// "c" in "code" is at index 5
-	if fg := getFg(screen, 5, 0); fg != mdInlineCodeColor {
-		t.Errorf("inline code color: got %v, want %v", fg, mdInlineCodeColor)
+	if fg := getFg(screen, 5, 0); fg != Zenburn.InlineCode {
+		t.Errorf("inline code color: got %v, want %v", fg, Zenburn.InlineCode)
 	}
 }
 
 func TestMarkdown_Link(t *testing.T) {
 	screen := setupScreen(t, 50, 1, []string{"click [here](http://example.com) now"})
-	applyMarkdownHighlighting(screen, 0, 0, 50, 1, false)
+	applyMarkdownHighlighting(screen, 0, 0, 50, 1, false, Zenburn)
 
 	// "h" in "here" at index 7
-	if fg := getFg(screen, 7, 0); fg != mdLinkTextColor {
-		t.Errorf("link text color: got %v, want %v", fg, mdLinkTextColor)
+	if fg := getFg(screen, 7, 0); fg != Zenburn.LinkText {
+		t.Errorf("link text color: got %v, want %v", fg, Zenburn.LinkText)
 	}
 	// "h" in "http" at index 14
-	if fg := getFg(screen, 14, 0); fg != mdLinkURLColor {
-		t.Errorf("link URL color: got %v, want %v", fg, mdLinkURLColor)
+	if fg := getFg(screen, 14, 0); fg != Zenburn.LinkURL {
+		t.Errorf("link URL color: got %v, want %v", fg, Zenburn.LinkURL)
 	}
 }
 
 func TestMarkdown_ListMarker(t *testing.T) {
 	screen := setupScreen(t, 40, 1, []string{"- list item"})
-	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false, Zenburn)
 
-	if fg := getFg(screen, 0, 0); fg != mdListMarkerColor {
-		t.Errorf("list marker color: got %v, want %v", fg, mdListMarkerColor)
+	if fg := getFg(screen, 0, 0); fg != Zenburn.ListMarker {
+		t.Errorf("list marker color: got %v, want %v", fg, Zenburn.ListMarker)
 	}
 	if !isBold(screen, 0, 0) {
 		t.Error("list marker should be bold")
@@ -170,16 +170,16 @@ func TestMarkdown_ListMarker(t *testing.T) {
 
 func TestMarkdown_Blockquote(t *testing.T) {
 	screen := setupScreen(t, 40, 1, []string{"> quoted text"})
-	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false, Zenburn)
 
-	if fg := getFg(screen, 0, 0); fg != mdBlockquoteColor {
-		t.Errorf("blockquote color: got %v, want %v", fg, mdBlockquoteColor)
+	if fg := getFg(screen, 0, 0); fg != Zenburn.Blockquote {
+		t.Errorf("blockquote color: got %v, want %v", fg, Zenburn.Blockquote)
 	}
 }
 
 func TestMarkdown_PlainTextUnchanged(t *testing.T) {
 	screen := setupScreen(t, 40, 1, []string{"just plain text"})
-	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false, Zenburn)
 
 	// Plain text should retain default style
 	_, _, style, _ := screen.GetContent(0, 0)

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -1,0 +1,211 @@
+package nve
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// mockScreen writes text into a simulated screen so we can test highlighting.
+func setupScreen(t *testing.T, width, height int, lines []string) tcell.SimulationScreen {
+	t.Helper()
+	screen := tcell.NewSimulationScreen("")
+	screen.Init()
+	screen.SetSize(width, height)
+
+	for row, line := range lines {
+		for col, r := range line {
+			if col >= width {
+				break
+			}
+			screen.SetContent(col, row, r, nil, tcell.StyleDefault)
+		}
+		// Fill remaining cols with spaces
+		for col := len(line); col < width; col++ {
+			screen.SetContent(col, row, ' ', nil, tcell.StyleDefault)
+		}
+	}
+	return screen
+}
+
+func getFg(screen tcell.Screen, col, row int) tcell.Color {
+	_, _, style, _ := screen.GetContent(col, row)
+	fg, _, _ := style.Decompose()
+	return fg
+}
+
+func isBold(screen tcell.Screen, col, row int) bool {
+	_, _, style, _ := screen.GetContent(col, row)
+	_, _, attrs := style.Decompose()
+	return attrs&tcell.AttrBold != 0
+}
+
+func isItalic(screen tcell.Screen, col, row int) bool {
+	_, _, style, _ := screen.GetContent(col, row)
+	_, _, attrs := style.Decompose()
+	return attrs&tcell.AttrItalic != 0
+}
+
+func TestMarkdown_Headings(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantColor tcell.Color
+	}{
+		{"heading1", "# Hello World", mdHeading1Color},
+		{"heading2", "## Subheading", mdHeading2Color},
+		{"heading3", "### Third Level", mdHeading3Color},
+		{"heading4", "#### Fourth Level", mdHeading3Color},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			screen := setupScreen(t, 40, 1, []string{tt.line})
+			applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+			if fg := getFg(screen, 0, 0); fg != tt.wantColor {
+				t.Errorf("color: got %v, want %v", fg, tt.wantColor)
+			}
+			if !isBold(screen, 0, 0) {
+				t.Error("heading should be bold")
+			}
+		})
+	}
+}
+
+func TestMarkdown_CodeFence(t *testing.T) {
+	lines := []string{
+		"```go",
+		"func main() {}",
+		"```",
+	}
+	screen := setupScreen(t, 40, 3, lines)
+	applyMarkdownHighlighting(screen, 0, 0, 40, 3, false)
+
+	// Fence line should be code color
+	if fg := getFg(screen, 0, 0); fg != mdInlineCodeColor {
+		t.Errorf("code fence color: got %v, want %v", fg, mdInlineCodeColor)
+	}
+	// Content inside fence should be code color
+	if fg := getFg(screen, 0, 1); fg != mdInlineCodeColor {
+		t.Errorf("code block content color: got %v, want %v", fg, mdInlineCodeColor)
+	}
+	// Closing fence should be code color
+	if fg := getFg(screen, 0, 2); fg != mdInlineCodeColor {
+		t.Errorf("closing fence color: got %v, want %v", fg, mdInlineCodeColor)
+	}
+}
+
+func TestMarkdown_CodeFenceStartInside(t *testing.T) {
+	lines := []string{
+		"some code here",
+		"```",
+	}
+	screen := setupScreen(t, 40, 2, lines)
+	// Start inside a code block (fence was above visible area)
+	applyMarkdownHighlighting(screen, 0, 0, 40, 2, true)
+
+	// First line should be code color (we're inside a code block)
+	if fg := getFg(screen, 0, 0); fg != mdInlineCodeColor {
+		t.Errorf("in-code-block content: got %v, want %v", fg, mdInlineCodeColor)
+	}
+}
+
+func TestMarkdown_Bold(t *testing.T) {
+	screen := setupScreen(t, 40, 1, []string{"some **bold** text"})
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+
+	// "b" in "bold" is at index 7
+	if !isBold(screen, 7, 0) {
+		t.Error("bold text should have bold attribute")
+	}
+	if fg := getFg(screen, 7, 0); fg != mdBoldColor {
+		t.Errorf("bold color: got %v, want %v", fg, mdBoldColor)
+	}
+}
+
+func TestMarkdown_Italic(t *testing.T) {
+	screen := setupScreen(t, 40, 1, []string{"some *italic* text"})
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+
+	// "i" in "italic" is at index 6
+	if !isItalic(screen, 6, 0) {
+		t.Error("italic text should have italic attribute")
+	}
+}
+
+func TestMarkdown_InlineCode(t *testing.T) {
+	screen := setupScreen(t, 40, 1, []string{"use `code` here"})
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+
+	// "c" in "code" is at index 5
+	if fg := getFg(screen, 5, 0); fg != mdInlineCodeColor {
+		t.Errorf("inline code color: got %v, want %v", fg, mdInlineCodeColor)
+	}
+}
+
+func TestMarkdown_Link(t *testing.T) {
+	screen := setupScreen(t, 50, 1, []string{"click [here](http://example.com) now"})
+	applyMarkdownHighlighting(screen, 0, 0, 50, 1, false)
+
+	// "h" in "here" at index 7
+	if fg := getFg(screen, 7, 0); fg != mdLinkTextColor {
+		t.Errorf("link text color: got %v, want %v", fg, mdLinkTextColor)
+	}
+	// "h" in "http" at index 14
+	if fg := getFg(screen, 14, 0); fg != mdLinkURLColor {
+		t.Errorf("link URL color: got %v, want %v", fg, mdLinkURLColor)
+	}
+}
+
+func TestMarkdown_ListMarker(t *testing.T) {
+	screen := setupScreen(t, 40, 1, []string{"- list item"})
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+
+	if fg := getFg(screen, 0, 0); fg != mdListMarkerColor {
+		t.Errorf("list marker color: got %v, want %v", fg, mdListMarkerColor)
+	}
+	if !isBold(screen, 0, 0) {
+		t.Error("list marker should be bold")
+	}
+}
+
+func TestMarkdown_Blockquote(t *testing.T) {
+	screen := setupScreen(t, 40, 1, []string{"> quoted text"})
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+
+	if fg := getFg(screen, 0, 0); fg != mdBlockquoteColor {
+		t.Errorf("blockquote color: got %v, want %v", fg, mdBlockquoteColor)
+	}
+}
+
+func TestMarkdown_PlainTextUnchanged(t *testing.T) {
+	screen := setupScreen(t, 40, 1, []string{"just plain text"})
+	applyMarkdownHighlighting(screen, 0, 0, 40, 1, false)
+
+	// Plain text should retain default style
+	_, _, style, _ := screen.GetContent(0, 0)
+	if style != tcell.StyleDefault {
+		t.Errorf("plain text style should be default, got %v", style)
+	}
+}
+
+func TestCountCodeFences(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		maxLine int
+		want    int
+	}{
+		{"no fences", "hello\nworld", 10, 0},
+		{"one fence", "hello\n```\ncode", 10, 1},
+		{"two fences", "```\ncode\n```\n", 10, 2},
+		{"maxLine limits", "```\ncode\n```\nmore", 2, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countCodeFences(tt.text, tt.maxLine)
+			if got != tt.want {
+				t.Errorf("countCodeFences() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds zenburn-inspired syntax highlighting for markdown files (.md, .mdown) in the content pane
- Highlights headings, bold, italic, inline code, code blocks, links, list markers, and blockquotes
- Introduces `MarkdownStyle` struct for future theming support; colors are parameterized, not hardcoded
- Applies highlighting via screen-cell post-processing in `Draw()`, layered before search term highlighting

## Test plan
- [x] Unit tests for all markdown element types (headings, bold, italic, code, links, lists, blockquotes)
- [x] Code fence state tracking tested (including mid-document scroll)
- [x] Plain text remains unstyled
- [x] `make test` passes
- [x] Visual verification with `go run --tags=fts5 cmd/main.go` against .md files
- [x] Compare side-by-side with `bat --style plain --theme=zenburn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)