### PR TITLE
Markdown list continuation and indentation

### DIFF
--- a/content_box.go
+++ b/content_box.go
@@ -196,6 +196,27 @@ func (b *ContentBox) InputHandler() func(event *tcell.EventKey, setFocus func(p 
 	return b.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
 		event = b.mapSpecialKeys(event)
 
+		// Intercept Enter in markdown files for list continuation.
+		if event.Key() == tcell.KeyEnter && b.isMarkdown() {
+			if b.handleListContinuation() {
+				return
+			}
+		}
+
+		// Intercept Tab/Shift-Tab on bullet lines for indentation.
+		if b.isMarkdown() {
+			if event.Key() == tcell.KeyTab {
+				if b.handleListIndent() {
+					return
+				}
+			}
+			if event.Key() == tcell.KeyBacktab {
+				if b.handleListDedent() {
+					return
+				}
+			}
+		}
+
 		before := b.GetText()
 
 		if handler := b.TextArea.InputHandler(); handler != nil {
@@ -207,6 +228,117 @@ func (b *ContentBox) InputHandler() func(event *tcell.EventKey, setFocus func(p 
 			b.queueSave(after)
 		}
 	})
+}
+
+// handleListContinuation checks the current line for a bullet prefix and
+// either continues the list or clears an empty bullet. Returns true if the
+// Enter key was consumed and should not be passed to TextArea.
+func (b *ContentBox) handleListContinuation() bool {
+	text := b.GetText()
+	_, start, _ := b.GetSelection()
+
+	// Find the start of the current line.
+	lineStart := strings.LastIndex(text[:start], "\n")
+	if lineStart < 0 {
+		lineStart = 0
+	} else {
+		lineStart++ // skip past the newline
+	}
+
+	currentLine := text[lineStart:start]
+	indent, marker, rest, ok := parseBulletPrefix(currentLine)
+	if !ok {
+		return false
+	}
+
+	if strings.TrimSpace(rest) == "" {
+		// Empty bullet line: remove the bullet and replace with a plain newline.
+		b.Replace(lineStart, start, "\n")
+	} else {
+		// Continue the list on the next line.
+		insertion := "\n" + nextBulletPrefix(indent, marker)
+		b.Replace(start, start, insertion)
+	}
+
+	b.dirty = true
+	b.queueSave(b.GetText())
+	return true
+}
+
+// handleListIndent inserts a tab at the beginning of the current line when
+// the cursor is on a bullet line. Returns true if the key was consumed.
+func (b *ContentBox) handleListIndent() bool {
+	text := b.GetText()
+	_, cursorPos, _ := b.GetSelection()
+
+	lineStart := strings.LastIndex(text[:cursorPos], "\n")
+	if lineStart < 0 {
+		lineStart = 0
+	} else {
+		lineStart++
+	}
+
+	currentLine := text[lineStart:cursorPos]
+	// Also consider text after the cursor on the same line.
+	lineEnd := strings.Index(text[cursorPos:], "\n")
+	if lineEnd < 0 {
+		lineEnd = len(text)
+	} else {
+		lineEnd += cursorPos
+	}
+	fullLine := text[lineStart:lineEnd]
+
+	if _, _, _, ok := parseBulletPrefix(currentLine); !ok {
+		if _, _, _, ok := parseBulletPrefix(fullLine); !ok {
+			return false
+		}
+	}
+
+	b.Replace(lineStart, lineStart, "\t")
+	// Restore cursor to its original relative position (shifted by the inserted tab).
+	b.Replace(cursorPos+1, cursorPos+1, "")
+	b.dirty = true
+	b.queueSave(b.GetText())
+	return true
+}
+
+// handleListDedent removes one leading tab from the current line when the
+// cursor is on a bullet line. Returns true if the key was consumed.
+func (b *ContentBox) handleListDedent() bool {
+	text := b.GetText()
+	_, cursorPos, _ := b.GetSelection()
+
+	lineStart := strings.LastIndex(text[:cursorPos], "\n")
+	if lineStart < 0 {
+		lineStart = 0
+	} else {
+		lineStart++
+	}
+
+	currentLine := text[lineStart:cursorPos]
+	lineEnd := strings.Index(text[cursorPos:], "\n")
+	if lineEnd < 0 {
+		lineEnd = len(text)
+	} else {
+		lineEnd += cursorPos
+	}
+	fullLine := text[lineStart:lineEnd]
+
+	if _, _, _, ok := parseBulletPrefix(currentLine); !ok {
+		if _, _, _, ok := parseBulletPrefix(fullLine); !ok {
+			return false
+		}
+	}
+
+	// Only dedent if the line starts with a tab.
+	if lineStart < len(text) && text[lineStart] == '\t' {
+		b.Replace(lineStart, lineStart+1, "")
+		// Restore cursor to its original relative position (shifted back by the removed tab).
+		b.Replace(cursorPos-1, cursorPos-1, "")
+		b.dirty = true
+		b.queueSave(b.GetText())
+	}
+	return true
 }
 
 func (b *ContentBox) mapSpecialKeys(event *tcell.EventKey) *tcell.EventKey {

--- a/content_box.go
+++ b/content_box.go
@@ -245,15 +245,24 @@ func (b *ContentBox) handleListContinuation() bool {
 		lineStart++ // skip past the newline
 	}
 
-	currentLine := text[lineStart:start]
-	indent, marker, rest, ok := parseBulletPrefix(currentLine)
+	// Use the full line (not just up to the cursor) so that bullet detection
+	// works correctly when the cursor is positioned within the marker.
+	lineEnd := strings.Index(text[start:], "\n")
+	if lineEnd < 0 {
+		lineEnd = len(text)
+	} else {
+		lineEnd += start
+	}
+
+	fullLine := text[lineStart:lineEnd]
+	indent, marker, rest, ok := parseBulletPrefix(fullLine)
 	if !ok {
 		return false
 	}
 
 	if strings.TrimSpace(rest) == "" {
 		// Empty bullet line: remove the bullet and replace with a plain newline.
-		b.Replace(lineStart, start, "\n")
+		b.Replace(lineStart, lineEnd, "\n")
 	} else {
 		// Continue the list on the next line.
 		insertion := "\n" + nextBulletPrefix(indent, marker)
@@ -334,7 +343,12 @@ func (b *ContentBox) handleListDedent() bool {
 	if lineStart < len(text) && text[lineStart] == '\t' {
 		b.Replace(lineStart, lineStart+1, "")
 		// Restore cursor to its original relative position (shifted back by the removed tab).
-		b.Replace(cursorPos-1, cursorPos-1, "")
+		// Clamp to lineStart to avoid underflow when cursor is at the start of the line.
+		newCursorPos := cursorPos - 1
+		if newCursorPos < lineStart {
+			newCursorPos = lineStart
+		}
+		b.Replace(newCursorPos, newCursorPos, "")
 		b.dirty = true
 		b.queueSave(b.GetText())
 	}

--- a/content_box_test.go
+++ b/content_box_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -143,6 +145,370 @@ func TestClear_VersioningDisabled_DoesNotSnapshot(t *testing.T) {
 	cb.dirty = true
 	cb.Clear()
 	assert.False(t, called, "should not snapshot on Clear when versioning is disabled")
+}
+
+func TestHandleListContinuation(t *testing.T) {
+	testcases := []struct {
+		name       string
+		filename   string
+		text       string
+		cursorPos  int
+		expectText string
+		expectUsed bool
+	}{
+		{
+			name:       "dash bullet continues on next line",
+			filename:   "note.md",
+			text:       "- hello",
+			cursorPos:  7,
+			expectText: "- hello\n- ",
+			expectUsed: true,
+		},
+		{
+			name:       "star bullet continues on next line",
+			filename:   "note.md",
+			text:       "* world",
+			cursorPos:  7,
+			expectText: "* world\n* ",
+			expectUsed: true,
+		},
+		{
+			name:       "indented dash preserves indent",
+			filename:   "note.md",
+			text:       "  - nested",
+			cursorPos:  10,
+			expectText: "  - nested\n  - ",
+			expectUsed: true,
+		},
+		{
+			name:       "numeric ordered increments",
+			filename:   "note.md",
+			text:       "1. first",
+			cursorPos:  8,
+			expectText: "1. first\n2. ",
+			expectUsed: true,
+		},
+		{
+			name:       "alpha ordered increments",
+			filename:   "note.md",
+			text:       "a. alpha",
+			cursorPos:  8,
+			expectText: "a. alpha\nb. ",
+			expectUsed: true,
+		},
+		{
+			name:       "empty dash bullet clears to newline",
+			filename:   "note.md",
+			text:       "- ",
+			cursorPos:  2,
+			expectText: "\n",
+			expectUsed: true,
+		},
+		{
+			name:       "empty star bullet clears to newline",
+			filename:   "note.md",
+			text:       "* ",
+			cursorPos:  2,
+			expectText: "\n",
+			expectUsed: true,
+		},
+		{
+			name:       "empty numeric bullet clears to newline",
+			filename:   "note.md",
+			text:       "1. ",
+			cursorPos:  3,
+			expectText: "\n",
+			expectUsed: true,
+		},
+		{
+			name:       "plain text not consumed",
+			filename:   "note.md",
+			text:       "just text",
+			cursorPos:  9,
+			expectText: "just text",
+			expectUsed: false,
+		},
+		{
+			name:       "cursor mid-line after bullet with trailing text",
+			filename:   "note.md",
+			text:       "- hello world",
+			cursorPos:  7,
+			expectText: "- hello\n-  world",
+			expectUsed: true,
+		},
+		{
+			name:       "multiline continues second line bullet",
+			filename:   "note.md",
+			text:       "- first\n- second",
+			cursorPos:  16,
+			expectText: "- first\n- second\n- ",
+			expectUsed: true,
+		},
+		{
+			name:       "multiline empty second bullet clears it",
+			filename:   "note.md",
+			text:       "- first\n- ",
+			cursorPos:  10,
+			expectText: "- first\n\n",
+			expectUsed: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := NewContentBox()
+			cb.saveVersion = func(string) {}
+			cb.currentFile = &FileRef{Filename: tc.filename}
+			cb.SetText(tc.text, false)
+
+			// Position cursor using Replace with empty text.
+			cb.Replace(tc.cursorPos, tc.cursorPos, "")
+
+			used := cb.handleListContinuation()
+			assert.Equal(t, tc.expectUsed, used, "consumed mismatch")
+			assert.Equal(t, tc.expectText, cb.GetText(), "text mismatch")
+		})
+	}
+}
+
+func TestListContinuation_NonMarkdownSkipped(t *testing.T) {
+	cb := NewContentBox()
+	cb.saveVersion = func(string) {}
+	cb.currentFile = &FileRef{Filename: "note.txt"}
+	cb.SetText("- hello", false)
+	cb.Replace(7, 7, "")
+
+	handler := cb.InputHandler()
+	enter := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	handler(enter, func(tview.Primitive) {})
+
+	// TextArea's default Enter inserts a newline, but no bullet prefix.
+	assert.Equal(t, "- hello\n", cb.GetText(), "non-markdown should get plain newline")
+}
+
+func TestListIndent(t *testing.T) {
+	testcases := []struct {
+		name            string
+		text            string
+		cursorPos       int
+		expectText      string
+		expectUsed      bool
+		expectCursorPos int
+	}{
+		{
+			name:            "tab indents dash bullet",
+			text:            "- item",
+			cursorPos:       6,
+			expectText:      "\t- item",
+			expectUsed:      true,
+			expectCursorPos: 7,
+		},
+		{
+			name:            "tab indents star bullet",
+			text:            "* item",
+			cursorPos:       6,
+			expectText:      "\t* item",
+			expectUsed:      true,
+			expectCursorPos: 7,
+		},
+		{
+			name:            "tab indents numeric bullet",
+			text:            "1. item",
+			cursorPos:       7,
+			expectText:      "\t1. item",
+			expectUsed:      true,
+			expectCursorPos: 8,
+		},
+		{
+			name:            "tab stacks on existing tab",
+			text:            "\t- item",
+			cursorPos:       7,
+			expectText:      "\t\t- item",
+			expectUsed:      true,
+			expectCursorPos: 8,
+		},
+		{
+			name:       "tab on non-bullet line is not consumed",
+			text:       "plain text",
+			cursorPos:  10,
+			expectText: "plain text",
+			expectUsed: false,
+		},
+		{
+			name:            "tab indents second line only",
+			text:            "- first\n- second",
+			cursorPos:       16,
+			expectText:      "- first\n\t- second",
+			expectUsed:      true,
+			expectCursorPos: 17,
+		},
+		{
+			name:            "tab on empty bullet line",
+			text:            "- ",
+			cursorPos:       2,
+			expectText:      "\t- ",
+			expectUsed:      true,
+			expectCursorPos: 3,
+		},
+		{
+			name:            "cursor mid-line preserves relative position",
+			text:            "- hello world",
+			cursorPos:       7,
+			expectText:      "\t- hello world",
+			expectUsed:      true,
+			expectCursorPos: 8,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := NewContentBox()
+			cb.saveVersion = func(string) {}
+			cb.currentFile = &FileRef{Filename: "note.md"}
+			cb.SetText(tc.text, false)
+			cb.Replace(tc.cursorPos, tc.cursorPos, "")
+
+			used := cb.handleListIndent()
+			assert.Equal(t, tc.expectUsed, used, "consumed mismatch")
+			assert.Equal(t, tc.expectText, cb.GetText(), "text mismatch")
+			if tc.expectUsed {
+				_, pos, _ := cb.GetSelection()
+				assert.Equal(t, tc.expectCursorPos, pos, "cursor position mismatch")
+			}
+		})
+	}
+}
+
+func TestListDedent(t *testing.T) {
+	testcases := []struct {
+		name            string
+		text            string
+		cursorPos       int
+		expectText      string
+		expectUsed      bool
+		expectDirty     bool
+		expectCursorPos int
+	}{
+		{
+			name:            "shift-tab removes leading tab",
+			text:            "\t- item",
+			cursorPos:       7,
+			expectText:      "- item",
+			expectUsed:      true,
+			expectDirty:     true,
+			expectCursorPos: 6,
+		},
+		{
+			name:            "shift-tab removes one tab when multiple",
+			text:            "\t\t- item",
+			cursorPos:       8,
+			expectText:      "\t- item",
+			expectUsed:      true,
+			expectDirty:     true,
+			expectCursorPos: 7,
+		},
+		{
+			name:        "shift-tab on unindented bullet is consumed but no change",
+			text:        "- item",
+			cursorPos:   6,
+			expectText:  "- item",
+			expectUsed:  true,
+			expectDirty: false,
+		},
+		{
+			name:        "shift-tab on non-bullet line not consumed",
+			text:        "\tplain text",
+			cursorPos:   11,
+			expectText:  "\tplain text",
+			expectUsed:  false,
+			expectDirty: false,
+		},
+		{
+			name:            "shift-tab dedents second line only",
+			text:            "- first\n\t- second",
+			cursorPos:       17,
+			expectText:      "- first\n- second",
+			expectUsed:      true,
+			expectDirty:     true,
+			expectCursorPos: 16,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := NewContentBox()
+			cb.saveVersion = func(string) {}
+			cb.currentFile = &FileRef{Filename: "note.md"}
+			cb.SetText(tc.text, false)
+			cb.Replace(tc.cursorPos, tc.cursorPos, "")
+			cb.dirty = false
+
+			used := cb.handleListDedent()
+			assert.Equal(t, tc.expectUsed, used, "consumed mismatch")
+			assert.Equal(t, tc.expectText, cb.GetText(), "text mismatch")
+			assert.Equal(t, tc.expectDirty, cb.dirty, "dirty mismatch")
+			if tc.expectDirty {
+				_, pos, _ := cb.GetSelection()
+				assert.Equal(t, tc.expectCursorPos, pos, "cursor position mismatch")
+			}
+		})
+	}
+}
+
+func TestListIndent_ViaInputHandler(t *testing.T) {
+	cb := NewContentBox()
+	cb.saveVersion = func(string) {}
+	cb.currentFile = &FileRef{Filename: "note.md"}
+	cb.SetText("- item", false)
+	cb.Replace(6, 6, "")
+
+	handler := cb.InputHandler()
+	tab := tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone)
+	handler(tab, func(tview.Primitive) {})
+
+	assert.Equal(t, "\t- item", cb.GetText(), "Tab via InputHandler should indent bullet line")
+}
+
+func TestListDedent_ViaInputHandler(t *testing.T) {
+	cb := NewContentBox()
+	cb.saveVersion = func(string) {}
+	cb.currentFile = &FileRef{Filename: "note.md"}
+	cb.SetText("\t- item", false)
+	cb.Replace(7, 7, "")
+
+	handler := cb.InputHandler()
+	backtab := tcell.NewEventKey(tcell.KeyBacktab, 0, tcell.ModNone)
+	handler(backtab, func(tview.Primitive) {})
+
+	assert.Equal(t, "- item", cb.GetText(), "Shift-Tab via InputHandler should dedent bullet line")
+}
+
+func TestListIndent_NonMarkdownSkipped(t *testing.T) {
+	cb := NewContentBox()
+	cb.saveVersion = func(string) {}
+	cb.currentFile = &FileRef{Filename: "note.txt"}
+	cb.SetText("- item", false)
+	cb.Replace(6, 6, "")
+
+	handler := cb.InputHandler()
+	tab := tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone)
+	handler(tab, func(tview.Primitive) {})
+
+	// TextArea's default Tab inserts a tab at cursor, not at line start.
+	assert.Equal(t, "- item\t", cb.GetText(), "non-markdown should get default tab behavior")
+}
+
+func TestListContinuation_SetsDirtyFlag(t *testing.T) {
+	cb := NewContentBox()
+	cb.saveVersion = func(string) {}
+	cb.currentFile = &FileRef{Filename: "note.md"}
+	cb.SetText("- item", false)
+	cb.Replace(6, 6, "")
+	cb.dirty = false
+
+	cb.handleListContinuation()
+
+	assert.True(t, cb.dirty, "dirty flag should be set after list continuation")
 }
 
 func TestShutdown_Versioning(t *testing.T) {

--- a/content_box_test.go
+++ b/content_box_test.go
@@ -229,6 +229,14 @@ func TestHandleListContinuation(t *testing.T) {
 			expectUsed: false,
 		},
 		{
+			name:       "cursor right after marker does not clear bullet",
+			filename:   "note.md",
+			text:       "- item",
+			cursorPos:  2,
+			expectText: "- \n- item",
+			expectUsed: true,
+		},
+		{
 			name:       "cursor mid-line after bullet with trailing text",
 			filename:   "note.md",
 			text:       "- hello world",
@@ -431,6 +439,15 @@ func TestListDedent(t *testing.T) {
 			expectUsed:      true,
 			expectDirty:     true,
 			expectCursorPos: 16,
+		},
+		{
+			name:            "shift-tab with cursor at line start clamps position",
+			text:            "\t- item",
+			cursorPos:       0,
+			expectText:      "- item",
+			expectUsed:      true,
+			expectDirty:     true,
+			expectCursorPos: 0,
 		},
 	}
 

--- a/content_box_test.go
+++ b/content_box_test.go
@@ -266,7 +266,7 @@ func TestHandleListContinuation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cb := NewContentBox()
 			cb.saveVersion = func(string) {}
-			cb.currentFile = &FileRef{Filename: tc.filename}
+			cb.currentFile = tempFileRef(t, tc.filename, tc.text)
 			cb.SetText(tc.text, false)
 
 			// Position cursor using Replace with empty text.
@@ -282,7 +282,7 @@ func TestHandleListContinuation(t *testing.T) {
 func TestListContinuation_NonMarkdownSkipped(t *testing.T) {
 	cb := NewContentBox()
 	cb.saveVersion = func(string) {}
-	cb.currentFile = &FileRef{Filename: "note.txt"}
+	cb.currentFile = tempFileRef(t, "note.txt", "- hello")
 	cb.SetText("- hello", false)
 	cb.Replace(7, 7, "")
 
@@ -372,7 +372,7 @@ func TestListIndent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cb := NewContentBox()
 			cb.saveVersion = func(string) {}
-			cb.currentFile = &FileRef{Filename: "note.md"}
+			cb.currentFile = tempFileRef(t, "note.md", tc.text)
 			cb.SetText(tc.text, false)
 			cb.Replace(tc.cursorPos, tc.cursorPos, "")
 
@@ -455,7 +455,7 @@ func TestListDedent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cb := NewContentBox()
 			cb.saveVersion = func(string) {}
-			cb.currentFile = &FileRef{Filename: "note.md"}
+			cb.currentFile = tempFileRef(t, "note.md", tc.text)
 			cb.SetText(tc.text, false)
 			cb.Replace(tc.cursorPos, tc.cursorPos, "")
 			cb.dirty = false
@@ -475,7 +475,7 @@ func TestListDedent(t *testing.T) {
 func TestListIndent_ViaInputHandler(t *testing.T) {
 	cb := NewContentBox()
 	cb.saveVersion = func(string) {}
-	cb.currentFile = &FileRef{Filename: "note.md"}
+	cb.currentFile = tempFileRef(t, "note.md", "- item")
 	cb.SetText("- item", false)
 	cb.Replace(6, 6, "")
 
@@ -489,7 +489,7 @@ func TestListIndent_ViaInputHandler(t *testing.T) {
 func TestListDedent_ViaInputHandler(t *testing.T) {
 	cb := NewContentBox()
 	cb.saveVersion = func(string) {}
-	cb.currentFile = &FileRef{Filename: "note.md"}
+	cb.currentFile = tempFileRef(t, "note.md", "\t- item")
 	cb.SetText("\t- item", false)
 	cb.Replace(7, 7, "")
 
@@ -503,7 +503,7 @@ func TestListDedent_ViaInputHandler(t *testing.T) {
 func TestListIndent_NonMarkdownSkipped(t *testing.T) {
 	cb := NewContentBox()
 	cb.saveVersion = func(string) {}
-	cb.currentFile = &FileRef{Filename: "note.txt"}
+	cb.currentFile = tempFileRef(t, "note.txt", "- item")
 	cb.SetText("- item", false)
 	cb.Replace(6, 6, "")
 
@@ -518,7 +518,7 @@ func TestListIndent_NonMarkdownSkipped(t *testing.T) {
 func TestListContinuation_SetsDirtyFlag(t *testing.T) {
 	cb := NewContentBox()
 	cb.saveVersion = func(string) {}
-	cb.currentFile = &FileRef{Filename: "note.md"}
+	cb.currentFile = tempFileRef(t, "note.md", "- item")
 	cb.SetText("- item", false)
 	cb.Replace(6, 6, "")
 	cb.dirty = false

--- a/list_continuation.go
+++ b/list_continuation.go
@@ -1,0 +1,111 @@
+package nve
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// parseBulletPrefix parses a line into its indentation, bullet marker, and
+// remaining text. It recognises unordered markers (- and *) and ordered
+// markers (numeric like "1." or alphabetic like "a."). Returns ok=false if
+// the line does not start with a recognised bullet pattern.
+func parseBulletPrefix(line string) (indent, marker, rest string, ok bool) {
+	// Extract leading whitespace.
+	trimmed := strings.TrimLeftFunc(line, unicode.IsSpace)
+	indent = line[:len(line)-len(trimmed)]
+
+	// Unordered: "- " or "* "
+	if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
+		marker = trimmed[:1]
+		rest = trimmed[2:]
+		return indent, marker, rest, true
+	}
+
+	// Ordered: digits followed by ". " (e.g. "1. ") or a single letter followed by ". " (e.g. "a. ")
+	dotIdx := strings.Index(trimmed, ". ")
+	if dotIdx < 1 {
+		return "", "", "", false
+	}
+
+	prefix := trimmed[:dotIdx]
+
+	// Numeric ordered list: all digits.
+	allDigits := true
+	for _, r := range prefix {
+		if !unicode.IsDigit(r) {
+			allDigits = false
+			break
+		}
+	}
+	if allDigits {
+		marker = prefix + "."
+		rest = trimmed[dotIdx+2:]
+		return indent, marker, rest, true
+	}
+
+	// Alpha ordered list: all lowercase letters.
+	allAlpha := true
+	for _, r := range prefix {
+		if r < 'a' || r > 'z' {
+			allAlpha = false
+			break
+		}
+	}
+	if allAlpha {
+		marker = prefix + "."
+		rest = trimmed[dotIdx+2:]
+		return indent, marker, rest, true
+	}
+
+	return "", "", "", false
+}
+
+// nextBulletPrefix returns the bullet prefix for the next list line,
+// including the trailing space. For unordered markers the same marker is
+// returned. For ordered markers the value is incremented.
+func nextBulletPrefix(indent, marker string) string {
+	// Unordered markers.
+	if marker == "-" || marker == "*" {
+		return indent + marker + " "
+	}
+
+	// Must end with "." for ordered markers.
+	if !strings.HasSuffix(marker, ".") {
+		return indent + marker + " "
+	}
+
+	val := marker[:len(marker)-1]
+
+	// Numeric: "1." → "2.", "99." → "100."
+	allDigits := true
+	for _, r := range val {
+		if !unicode.IsDigit(r) {
+			allDigits = false
+			break
+		}
+	}
+	if allDigits {
+		n := 0
+		for _, r := range val {
+			n = n*10 + int(r-'0')
+		}
+		return indent + fmt.Sprintf("%d. ", n+1)
+	}
+
+	// Alpha: "a." → "b.", "z." → "aa."
+	return indent + incrementAlpha(val) + ". "
+}
+
+// incrementAlpha increments an alphabetic string: "a" → "b", "z" → "aa", "az" → "ba".
+func incrementAlpha(s string) string {
+	runes := []rune(s)
+	for i := len(runes) - 1; i >= 0; i-- {
+		if runes[i] < 'z' {
+			runes[i]++
+			return string(runes)
+		}
+		runes[i] = 'a'
+	}
+	return "a" + string(runes)
+}

--- a/list_continuation.go
+++ b/list_continuation.go
@@ -22,7 +22,7 @@ func parseBulletPrefix(line string) (indent, marker, rest string, ok bool) {
 		return indent, marker, rest, true
 	}
 
-	// Ordered: digits followed by ". " (e.g. "1. ") or a single letter followed by ". " (e.g. "a. ")
+	// Ordered: digits followed by ". " (e.g. "1. ") or one or more lowercase letters followed by ". " (e.g. "a. ", "aa. ")
 	dotIdx := strings.Index(trimmed, ". ")
 	if dotIdx < 1 {
 		return "", "", "", false

--- a/list_continuation_test.go
+++ b/list_continuation_test.go
@@ -1,0 +1,255 @@
+package nve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBulletPrefix(t *testing.T) {
+	testcases := []struct {
+		name         string
+		line         string
+		expectOK     bool
+		expectIndent string
+		expectMarker string
+		expectRest   string
+	}{
+		{
+			name:         "dash bullet",
+			line:         "- hello",
+			expectOK:     true,
+			expectIndent: "",
+			expectMarker: "-",
+			expectRest:   "hello",
+		},
+		{
+			name:         "star bullet",
+			line:         "* world",
+			expectOK:     true,
+			expectIndent: "",
+			expectMarker: "*",
+			expectRest:   "world",
+		},
+		{
+			name:         "indented dash",
+			line:         "  - indented",
+			expectOK:     true,
+			expectIndent: "  ",
+			expectMarker: "-",
+			expectRest:   "indented",
+		},
+		{
+			name:         "deeply indented star",
+			line:         "    * deep",
+			expectOK:     true,
+			expectIndent: "    ",
+			expectMarker: "*",
+			expectRest:   "deep",
+		},
+		{
+			name:         "numeric ordered",
+			line:         "1. first item",
+			expectOK:     true,
+			expectIndent: "",
+			expectMarker: "1.",
+			expectRest:   "first item",
+		},
+		{
+			name:         "multi-digit numeric",
+			line:         "99. ninety-ninth",
+			expectOK:     true,
+			expectIndent: "",
+			expectMarker: "99.",
+			expectRest:   "ninety-ninth",
+		},
+		{
+			name:         "alpha ordered",
+			line:         "a. alpha item",
+			expectOK:     true,
+			expectIndent: "",
+			expectMarker: "a.",
+			expectRest:   "alpha item",
+		},
+		{
+			name:         "indented numeric",
+			line:         "   3. third",
+			expectOK:     true,
+			expectIndent: "   ",
+			expectMarker: "3.",
+			expectRest:   "third",
+		},
+		{
+			name:         "empty dash bullet",
+			line:         "- ",
+			expectOK:     true,
+			expectIndent: "",
+			expectMarker: "-",
+			expectRest:   "",
+		},
+		{
+			name:         "empty star bullet",
+			line:         "* ",
+			expectOK:     true,
+			expectIndent: "",
+			expectMarker: "*",
+			expectRest:   "",
+		},
+		{
+			name:         "empty numeric bullet",
+			line:         "1. ",
+			expectOK:     true,
+			expectIndent: "",
+			expectMarker: "1.",
+			expectRest:   "",
+		},
+		{
+			name:     "plain text",
+			line:     "just plain text",
+			expectOK: false,
+		},
+		{
+			name:     "empty string",
+			line:     "",
+			expectOK: false,
+		},
+		{
+			name:     "blockquote",
+			line:     "> quoted text",
+			expectOK: false,
+		},
+		{
+			name:     "heading",
+			line:     "# heading",
+			expectOK: false,
+		},
+		{
+			name:     "dash without space",
+			line:     "-nospace",
+			expectOK: false,
+		},
+		{
+			name:     "number without space after dot",
+			line:     "1.nospace",
+			expectOK: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			indent, marker, rest, ok := parseBulletPrefix(tc.line)
+			assert.Equal(t, tc.expectOK, ok, "ok mismatch")
+			if ok {
+				assert.Equal(t, tc.expectIndent, indent, "indent mismatch")
+				assert.Equal(t, tc.expectMarker, marker, "marker mismatch")
+				assert.Equal(t, tc.expectRest, rest, "rest mismatch")
+			}
+		})
+	}
+}
+
+func TestNextBulletPrefix(t *testing.T) {
+	testcases := []struct {
+		name   string
+		indent string
+		marker string
+		expect string
+	}{
+		{
+			name:   "dash",
+			indent: "",
+			marker: "-",
+			expect: "- ",
+		},
+		{
+			name:   "star",
+			indent: "",
+			marker: "*",
+			expect: "* ",
+		},
+		{
+			name:   "indented dash",
+			indent: "  ",
+			marker: "-",
+			expect: "  - ",
+		},
+		{
+			name:   "numeric 1 to 2",
+			indent: "",
+			marker: "1.",
+			expect: "2. ",
+		},
+		{
+			name:   "numeric 99 to 100",
+			indent: "",
+			marker: "99.",
+			expect: "100. ",
+		},
+		{
+			name:   "alpha a to b",
+			indent: "",
+			marker: "a.",
+			expect: "b. ",
+		},
+		{
+			name:   "alpha z to aa",
+			indent: "",
+			marker: "z.",
+			expect: "aa. ",
+		},
+		{
+			name:   "indented numeric",
+			indent: "   ",
+			marker: "3.",
+			expect: "   4. ",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := nextBulletPrefix(tc.indent, tc.marker)
+			assert.Equal(t, tc.expect, result)
+		})
+	}
+}
+
+func TestIncrementAlpha(t *testing.T) {
+	testcases := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "a to b",
+			input:  "a",
+			expect: "b",
+		},
+		{
+			name:   "y to z",
+			input:  "y",
+			expect: "z",
+		},
+		{
+			name:   "z to aa",
+			input:  "z",
+			expect: "aa",
+		},
+		{
+			name:   "az to ba",
+			input:  "az",
+			expect: "ba",
+		},
+		{
+			name:   "zz to aaa",
+			input:  "zz",
+			expect: "aaa",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := incrementAlpha(tc.input)
+			assert.Equal(t, tc.expect, result)
+		})
+	}
+}

--- a/tui_test.go
+++ b/tui_test.go
@@ -85,8 +85,8 @@ func TestTUI_ExternalFileCreate(t *testing.T) {
 
 func TestTUI_ExternalFileDelete(t *testing.T) {
 	h := NewTUIHarness(t, map[string]string{
-		"keeper.md":  "I stay",
-		"goner.md":   "I go away",
+		"keeper.md": "I stay",
+		"goner.md":  "I go away",
 	})
 
 	// Wait for both files


### PR DESCRIPTION
## Summary

Adds smart bullet list handling for markdown files in the ContentBox editor:

- **Enter key**: Continues the list on the next line with the same indentation and marker (or incremented number/letter for ordered lists). Pressing Enter on an empty bullet line clears the bullet and exits list mode.
- **Tab key**: Indents a bullet line by inserting a tab at the start, preserving the cursor's relative position.
- **Shift+Tab key**: Dedents a bullet line by removing one leading tab (if present), preserving cursor position.

## Implementation

New file `list_continuation.go` provides pure parsing logic: `parseBulletPrefix()` parses unordered (- *) and ordered (1., a.) bullet patterns, and `nextBulletPrefix()` generates the next continuation prefix with proper increment handling.

ContentBox intercepts Enter/Tab/Shift-Tab keys in markdown files and delegates to new handlers: `handleListContinuation()`, `handleListIndent()`, and `handleListDedent()`.

All changes are isolated to markdown files; plain text files continue to use default TextArea behavior.

## Testing

Added 20+ table-driven tests covering all bullet types, indentation, cursor positioning, multiline documents, and edge cases. All existing tests pass.